### PR TITLE
Adding $schema to the plugin.schema.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A tool for validating community plugins for publishing to Grafana.com.
 
 Currently only supports plugins hosted on GitHub.
 
+## Local validation of plugin.json
+
+Adding `https://raw.githubusercontent.com/grafana/plugin-validator/master/config/plugin.schema.json` as `$schema` of the `plugin.json` will help you to locally validate the file. This will also allows you to improve the `plugin.json` authoring experience with auto complete in IDEs.
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently only supports plugins hosted on GitHub.
 
 ## Local validation of plugin.json
 
-Adding `https://raw.githubusercontent.com/grafana/plugin-validator/master/config/plugin.schema.json` as `$schema` of the `plugin.json` will help you to locally validate the file. This will also allows you to improve the `plugin.json` authoring experience with auto complete in IDEs.
+Adding `https://raw.githubusercontent.com/grafana/plugin-validator/master/config/plugin.schema.json` as `$schema` of the `plugin.json` will help you to locally validate the file without installing the **plugincheck**. This will also allows you to improve the `plugin.json` authoring experience with auto complete in IDEs.
 
 ## Install
 

--- a/config/plugin.schema.json
+++ b/config/plugin.schema.json
@@ -7,6 +7,11 @@
   "required": ["type", "name", "id", "info", "dependencies"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+        "type": "string",
+        "description": "Schema definition for the plugin.json file",
+        "enum": ["https://raw.githubusercontent.com/grafana/plugin-validator/master/config/plugin.schema.json"]
+    },
     "id": {
       "type": "string",
       "description": "Unique name of the plugin. If the plugin is published on grafana.com, then the plugin id has to follow the naming conventions.",


### PR DESCRIPTION
Adding $schema property to the `plugin.schema.json` file. This will help IDEs to autocomplete and lint `plugin.json` file. Fixes #1