### PR TITLE
fix file:/// paths properly in Windows, Linux, MacOSX

### DIFF
--- a/pkg/plugin/check.go
+++ b/pkg/plugin/check.go
@@ -55,7 +55,7 @@ type ValidationComment struct {
 var ErrPluginNotFound = errors.New("plugin not found")
 
 func readArchive(archiveURL string) ([]byte, error) {
-	if strings.HasPrefix(archiveURL, "https://") || strings.HasPrefix(archiveURL, "https://") {
+	if strings.HasPrefix(archiveURL, "https://") || strings.HasPrefix(archiveURL, "http://") {
 		resp, err := http.Get(archiveURL)
 		if err != nil {
 			return nil, err

--- a/pkg/plugin/checkers.go
+++ b/pkg/plugin/checkers.go
@@ -353,8 +353,8 @@ func (c *jsonSchemaChecker) check(ctx *checkContext) ([]ValidationComment, error
 		return nil, err
 	}
 
-	schemaLoader := gojsonschema.NewReferenceLoader("file://" + schemaPath)
-	documentLoader := gojsonschema.NewReferenceLoader("file://" + ctx.MetadataPath)
+	schemaLoader := gojsonschema.NewReferenceLoader("file:///" + schemaPath)
+	documentLoader := gojsonschema.NewReferenceLoader("file:///" + ctx.MetadataPath)
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {


### PR DESCRIPTION
under windows, I successful compiled `plugincheck`
but got error
```
>plugincheck.exe ./vertamedia-clickhouse-datasource-2.2.0.zip

parse "file://C:\\Users\\Slach\\AppData\\Local\\Temp\\plugin_162473759.schema.json": invalid port ":\\Users\\Slach\\AppData\\Local\\Temp\\plugin_162473759.schema.json" after host                                                                                                         
```

during try load JSON scheme

Also,  I checked these changes under Linux via docker and Linux
```
 docker run -v ./:/go/src/github.com/grafana/plugin-validator -w /go/src/github.com/grafana/plugin-validator golang:latest bash -c "go build -o plugincheck ./cmd/plugincheck/main.go && ./plugincheck ./vertamedia-clickhouse-datasource-2.2.0.zip"
```
