### PR TITLE
fix: add User-Agent to bypass scrape protection (e.g. twitter)

### DIFF
--- a/pkg/plugin/checkers.go
+++ b/pkg/plugin/checkers.go
@@ -201,7 +201,14 @@ func (c linkChecker) check(ctx *checkContext) ([]ValidationComment, error) {
 		go func(url string) {
 			defer wg.Done()
 
-			resp, err := http.Get(url)
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				brokenCh <- urlstatus{url: url, status: err.Error()}
+				return
+			}
+			req.Header.Add("User-Agent", "Mozilla/5.0 (compatible; GrafanaPluginValidatorBot; +https://github.com/grafana/plugin-validator)")
+
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				brokenCh <- urlstatus{url: url, status: err.Error()}
 				return


### PR DESCRIPTION
Hello! I have an URL to twitter.com in the plugin's README.md. Url checker gives this message:

```
$ plugincheck plugin.zip
{
  "level": "error",
  "message": "README contains a broken link",
  "details": "Something went wrong when we tried looking up [https://twitter.com/%USERNAME%](https://twitter.com/%USERNAME%) (`400 Bad Request`)."
}
$ echo $?
1
```

There are no errors if a request has a "User-Agent" header with the "Bot" suffix.