### PR TITLE
Add check for tracking scripts

### DIFF
--- a/pkg/plugin/check.go
+++ b/pkg/plugin/check.go
@@ -186,6 +186,7 @@ func Check(archiveURL string, schemaPath string, client *grafana.Client) (json.R
 		// &largeFileChecker{},
 		&developerJargonChecker{},
 		&templateReadmeChecker{},
+		&trackingChecker{},
 		&grafanaDependencyChecker{},
 	}
 

--- a/pkg/plugin/checkers.go
+++ b/pkg/plugin/checkers.go
@@ -41,7 +41,7 @@ func (c *trackingChecker) check(ctx *checkContext) ([]ValidationComment, error) 
 				{
 					Severity: checkSeverityWarning,
 					Message:  "Plugin contains tracking scripts",
-					Details:  fmt.Sprintf("We detected what looks like a tracking script in your plugin. Plugins are not allowed to track activities of Grafana users. Please remove any user tracking from the plugin and submit it again."),
+					Details:  "We detected what looks like a tracking script in your plugin. Plugins are not allowed to track activities of Grafana users. Please remove any user tracking from the plugin and submit it again.",
 				},
 			}, nil
 		}


### PR DESCRIPTION
This adds a checker that scans the minified source code for known tracking URLs. This should be an error, but to avoid breaking people's builds, I've made it a warning for now while we test it.

It's not a foolproof method to detect tracking scripts, but at least we should catch mistakes.