### PR TITLE
Add flag to report private signatures check error as warning

### DIFF
--- a/cmd/plugincheck/main.go
+++ b/cmd/plugincheck/main.go
@@ -15,7 +15,8 @@ import (
 
 func main() {
 	var (
-		strictFlag = flag.Bool("strict", false, "If set, plugincheck returns non-zero exit code for warnings")
+		strictFlag  = flag.Bool("strict", false, "If set, plugincheck returns non-zero exit code for warnings")
+		privateFlag = flag.Bool("private", false, "If set, plugincheck reports private signature check error as warning")
 	)
 
 	flag.Parse()
@@ -49,7 +50,7 @@ func main() {
 
 	client := grafana.NewClient()
 
-	_, result, err := plugin.Check(pluginURL, schemaFile.Name(), client)
+	_, result, err := plugin.Check(pluginURL, schemaFile.Name(), *privateFlag, client)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/plugincheck/main.go
+++ b/cmd/plugincheck/main.go
@@ -21,12 +21,12 @@ func main() {
 
 	flag.Parse()
 
-	if len(os.Args) < 2 {
+	if len(flag.Args()) < 1 {
 		fmt.Fprintln(os.Stderr, "missing plugin url")
 		os.Exit(1)
 	}
 
-	pluginURL := os.Args[1]
+	pluginURL := flag.Arg(0)
 
 	schemaFile, err := ioutil.TempFile("", "plugin_*.schema.json")
 	if err != nil {

--- a/pkg/plugin/check.go
+++ b/pkg/plugin/check.go
@@ -76,7 +76,7 @@ func readArchive(archiveURL string) ([]byte, error) {
 }
 
 // Check executes a number of checks to validate a plugin.
-func Check(archiveURL string, schemaPath string, client *grafana.Client) (json.RawMessage, []ValidationComment, error) {
+func Check(archiveURL string, schemaPath string, private bool, client *grafana.Client) (json.RawMessage, []ValidationComment, error) {
 	b, err := readArchive(archiveURL)
 
 	// Extract the ZIP archive in a temporary directory.
@@ -179,7 +179,7 @@ func Check(archiveURL string, schemaPath string, client *grafana.Client) (json.R
 		&jsonSchemaChecker{schema: schemaPath},
 		&archiveChecker{},
 		&manifestChecker{},
-		&privateSignatureChecker{},
+		&privateSignatureChecker{private},
 		&linkChecker{},
 		&pluginPlatformChecker{},
 		&screenshotChecker{},

--- a/pkg/plugin/checkers.go
+++ b/pkg/plugin/checkers.go
@@ -112,7 +112,9 @@ func (c archiveChecker) check(ctx *checkContext) ([]ValidationComment, error) {
 	return nil, nil
 }
 
-type privateSignatureChecker struct{}
+type privateSignatureChecker struct {
+	severityWarning bool
+}
 
 func (c privateSignatureChecker) check(ctx *checkContext) ([]ValidationComment, error) {
 	manifestPath := filepath.Join(ctx.RootDir, "MANIFEST.txt")
@@ -127,9 +129,14 @@ func (c privateSignatureChecker) check(ctx *checkContext) ([]ValidationComment, 
 		return nil, err
 	}
 
+	severity := checkSeverityError
+	if c.severityWarning {
+		severity = checkSeverityWarning
+	}
+
 	if manifest.SignatureType == "private" {
 		return []ValidationComment{{
-			Severity: checkSeverityError,
+			Severity: severity,
 			Message:  "Plugin has a private signature",
 			Details:  "Plugins that are published on Grafana.com must be signed under a **commercial** or **community** signature level. For more information, refer to [Plugin signature levels](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#plugin-signature-levels).",
 		}}, nil


### PR DESCRIPTION
I would like to validate a private plugin so I've added a flag to report private signature check error as warning.

Is this an acceptable solution?