### PR TITLE
Make checks configurable for plugincheck2

### DIFF
--- a/cmd/plugincheck2/config/private-plugin.yaml
+++ b/cmd/plugincheck2/config/private-plugin.yaml
@@ -1,0 +1,9 @@
+global:
+  enabled: true
+  severity: error
+
+analyzers:
+  signature:
+    rules:
+      private-signature:
+        enabled: false

--- a/cmd/plugincheck2/config/publishing.yaml
+++ b/cmd/plugincheck2/config/publishing.yaml
@@ -1,0 +1,15 @@
+global:
+  enabled: true
+  severity: error
+
+analyzers:
+  htmlreadme:
+    severity: warning
+  legacyplatform:
+    severity: warning
+  jargon:
+    severity: warning
+  restrictivedep:
+    severity: warning
+  screenshots:
+    severity: warning

--- a/cmd/plugincheck2/config/strict.yaml
+++ b/cmd/plugincheck2/config/strict.yaml
@@ -1,0 +1,3 @@
+global:
+  enabled: true
+  severity: error

--- a/cmd/plugincheck2/main.go
+++ b/cmd/plugincheck2/main.go
@@ -4,45 +4,59 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes"
 	"github.com/grafana/plugin-validator/pkg/runner"
+	"gopkg.in/yaml.v2"
 )
 
 func main() {
 	var (
 		strictFlag = flag.Bool("strict", false, "If set, plugincheck returns non-zero exit code for warnings")
+		configFlag = flag.String("config", "", "Path to configuration file")
 	)
 
 	flag.Parse()
+
+	if *configFlag == "" {
+		fmt.Fprintln(os.Stderr, "missing config")
+		os.Exit(1)
+	}
+
+	cfg, err := readConfigFile(*configFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Errorf("couldn't read configuration: %w", err))
+		os.Exit(1)
+	}
 
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "missing plugin url")
 		os.Exit(1)
 	}
 
-	pluginURL := os.Args[1]
+	pluginURL := flag.Args()[0]
 
 	b, err := readArchive(pluginURL)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, fmt.Errorf("couldn't fetch plugin archive: %w", err))
 		os.Exit(1)
 	}
 
 	// Extract the ZIP archive in a temporary directory.
 	archiveDir, cleanup, err := extractPlugin(bytes.NewReader(b))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, fmt.Errorf("couldn't extract plugin archive: %w", err))
 		os.Exit(1)
 	}
 	defer cleanup()
 
-	diags, err := runner.Check(passes.Analyzers, archiveDir)
+	diags, err := runner.Check(passes.Analyzers, archiveDir, cfg)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, fmt.Errorf("check failed: %w", err))
 		os.Exit(1)
 	}
 
@@ -71,4 +85,18 @@ func main() {
 	}
 
 	os.Exit(exitCode)
+}
+
+func readConfigFile(path string) (runner.Config, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return runner.Config{}, err
+	}
+
+	var config runner.Config
+	if err := yaml.Unmarshal(b, &config); err != nil {
+		return runner.Config{}, err
+	}
+
+	return config, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,3 +28,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepx
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -1,5 +1,9 @@
 package analysis
 
+import (
+	"fmt"
+)
+
 type Severity string
 
 var (
@@ -13,14 +17,35 @@ type Pass struct {
 	Report   func(Diagnostic)
 }
 
+func (p *Pass) Reportf(rule *Rule, message string, as ...string) {
+	var is []interface{}
+	for _, a := range as {
+		is = append(is, a)
+	}
+
+	if rule.Enabled {
+		p.Report(Diagnostic{
+			Severity: rule.Severity,
+			Message:  fmt.Sprintf(message, is...),
+		})
+	}
+}
+
 type Diagnostic struct {
 	Severity Severity
 	Message  string
 	Context  string
 }
 
+type Rule struct {
+	Name     string
+	Enabled  bool
+	Severity Severity
+}
+
 type Analyzer struct {
 	Name     string
 	Requires []*Analyzer
 	Run      func(pass *Pass) (interface{}, error)
+	Rules    []*Rule
 }

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -18,17 +18,19 @@ type Pass struct {
 }
 
 func (p *Pass) Reportf(rule *Rule, message string, as ...string) {
+	if rule.Disabled {
+		return
+	}
+
 	var is []interface{}
 	for _, a := range as {
 		is = append(is, a)
 	}
 
-	if rule.Enabled {
-		p.Report(Diagnostic{
-			Severity: rule.Severity,
-			Message:  fmt.Sprintf(message, is...),
-		})
-	}
+	p.Report(Diagnostic{
+		Severity: rule.Severity,
+		Message:  fmt.Sprintf(message, is...),
+	})
 }
 
 type Diagnostic struct {
@@ -39,7 +41,7 @@ type Diagnostic struct {
 
 type Rule struct {
 	Name     string
-	Enabled  bool
+	Disabled bool
 	Severity Severity
 }
 

--- a/pkg/analysis/passes/archive/archive.go
+++ b/pkg/analysis/passes/archive/archive.go
@@ -8,9 +8,17 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
+var (
+	emptyArchive   = &analysis.Rule{Name: "empty-archive"}
+	moreThanOneDir = &analysis.Rule{Name: "more-than-one-dir"}
+	noRootDir      = &analysis.Rule{Name: "no-root-dir"}
+	dist           = &analysis.Rule{Name: "dist"}
+)
+
 var Analyzer = &analysis.Analyzer{
-	Name: "archive",
-	Run:  run,
+	Name:  "archive",
+	Run:   run,
+	Rules: []*analysis.Rule{emptyArchive, moreThanOneDir, noRootDir, dist},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -20,26 +28,17 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if len(fis) == 0 {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  "archive is empty",
-		})
+		pass.Reportf(emptyArchive, "archive is empty")
 		return nil, nil
 	}
 
 	if len(fis) != 1 {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  "archive contains more than one directory",
-		})
+		pass.Reportf(moreThanOneDir, "archive contains more than one directory")
 		return nil, nil
 	}
 
 	if !fis[0].IsDir() {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  "archive does not contain a identifying directory",
-		})
+		pass.Reportf(noRootDir, "archive does not contain a root directory")
 		return nil, nil
 	}
 
@@ -54,10 +53,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, err
 	}
 
-	pass.Report(analysis.Diagnostic{
-		Severity: analysis.Error,
-		Message:  "dist should be renamed to plugin id and moved to root",
-	})
+	pass.Reportf(dist, "dist should be renamed to plugin id and moved to root")
 
 	return legacyRoot, nil
 }

--- a/pkg/analysis/passes/archive/archive_test.go
+++ b/pkg/analysis/passes/archive/archive_test.go
@@ -70,7 +70,7 @@ func TestEmpty(t *testing.T) {
 		Report: func(d analysis.Diagnostic) {
 			invoked = true
 
-			if d.Message != "archive does not contain a identifying directory" {
+			if d.Message != "archive does not contain a root directory" {
 				t.Errorf("unexpected diagnostic message: %q", d.Message)
 			}
 		},

--- a/pkg/analysis/passes/archive/archive_test.go
+++ b/pkg/analysis/passes/archive/archive_test.go
@@ -70,7 +70,7 @@ func TestEmpty(t *testing.T) {
 		Report: func(d analysis.Diagnostic) {
 			invoked = true
 
-			if d.Message != "Invalid archive structure" {
+			if d.Message != "archive does not contain a identifying directory" {
 				t.Errorf("unexpected diagnostic message: %q", d.Message)
 			}
 		},

--- a/pkg/analysis/passes/archivename/archivename.go
+++ b/pkg/analysis/passes/archivename/archivename.go
@@ -2,7 +2,6 @@ package archivename
 
 import (
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -10,10 +9,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 )
 
+var (
+	noIdentRootDir = &analysis.Rule{Name: "no-ident-root-dir"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "archivename",
 	Requires: []*analysis.Analyzer{archive.Analyzer, metadata.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{noIdentRootDir},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -34,10 +38,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if data.ID != "" && base != data.ID {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  fmt.Sprintf("archive should contain a directory named %s", data.ID),
-		})
+		pass.Reportf(noIdentRootDir, "archive should contain a directory named %s", data.ID)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/htmlreadme/htmlreadme.go
+++ b/pkg/analysis/passes/htmlreadme/htmlreadme.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 )
 
+var (
+	noHTMLReadme = &analysis.Rule{Name: "no-html-readme"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "htmlreadme",
 	Requires: []*analysis.Analyzer{readme.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{noHTMLReadme},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -19,11 +24,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	re := regexp.MustCompile("</[a-z]+>")
 
 	if re.Match(readme) {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "html is not supported and will not render correctly",
-			Context:  "README.md",
-		})
+		pass.Reportf(noHTMLReadme, "README.md: html is not supported and will not render correctly")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/htmlreadme/htmlreadme_test.go
+++ b/pkg/analysis/passes/htmlreadme/htmlreadme_test.go
@@ -49,7 +49,7 @@ func TestHTML(t *testing.T) {
 			readme.Analyzer: b,
 		},
 		Report: func(d analysis.Diagnostic) {
-			if d.Message != "README contains HTML" {
+			if d.Message != "README.md: html is not supported and will not render correctly" {
 				t.Errorf("unexpected diagnostic message: %q", d.Message)
 			}
 			invoked = true

--- a/pkg/analysis/passes/jargon/jargon.go
+++ b/pkg/analysis/passes/jargon/jargon.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 )
 
+var (
+	developerJargon = &analysis.Rule{Name: "developer-jargon"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "jargon",
 	Requires: []*analysis.Analyzer{readme.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{developerJargon},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -29,11 +34,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if len(found) > 0 {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "remove developer jargon for more user-friendly docs",
-			Context:  "README.md",
-		})
+		pass.Reportf(developerJargon, "README.md: remove developer jargon for more user-friendly docs")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
 )
 
+var (
+	legacyPlatform = &analysis.Rule{Name: "legacy-platform"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "legacyplatform",
 	Requires: []*analysis.Analyzer{modulejs.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{legacyPlatform},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -22,11 +27,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	)
 
 	if angularExp.Match(module) && !reactExp.Match(module) {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "uses legacy plugin platform",
-			Context:  "module.js",
-		})
+		pass.Reportf(legacyPlatform, "module.js: uses legacy plugin platform")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -9,10 +9,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 )
 
+var (
+	unsignedPlugin = &analysis.Rule{Name: "unsigned-plugin"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "manifest",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{unsignedPlugin},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -21,10 +26,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := ioutil.ReadFile(filepath.Join(archiveDir, "MANIFEST.txt"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Error,
-				Message:  "unsigned plugin",
-			})
+			pass.Reportf(unsignedPlugin, "unsigned plugin")
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/analysis/passes/metadata/metadata.go
+++ b/pkg/analysis/passes/metadata/metadata.go
@@ -9,10 +9,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 )
 
+var (
+	missingMetadata = &analysis.Rule{Name: "missing-metadata"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "metadata",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{missingMetadata},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -21,10 +26,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := ioutil.ReadFile(filepath.Join(archiveDir, "plugin.json"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Error,
-				Message:  "missing plugin.json",
-			})
+			pass.Reportf(missingMetadata, "missing plugin.json")
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/analysis/passes/metadatavalid/metadatavalid.go
+++ b/pkg/analysis/passes/metadatavalid/metadatavalid.go
@@ -15,10 +15,15 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
+var (
+	invalidMetadata = &analysis.Rule{Name: "invalid-metadata"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "metadatavalid",
 	Requires: []*analysis.Analyzer{metadata.Analyzer, metadataschema.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{invalidMetadata},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -59,11 +64,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	for _, desc := range result.Errors() {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  fmt.Sprintf("%s: %s", desc.Field(), desc.Description()),
-			Context:  "plugin.json",
-		})
+		pass.Reportf(invalidMetadata, fmt.Sprintf("plugin.json: %s: %s", desc.Field(), desc.Description()))
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/modulejs/modulejs.go
+++ b/pkg/analysis/passes/modulejs/modulejs.go
@@ -9,10 +9,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 )
 
+var (
+	missingModulejs = &analysis.Rule{Name: "missing-modulejs"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "modulejs",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{missingModulejs},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -21,10 +26,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := ioutil.ReadFile(filepath.Join(archiveDir, "module.js"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Error,
-				Message:  "missing module.js",
-			})
+			pass.Reportf(missingModulejs, "missing module.js")
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/analysis/passes/org/org.go
+++ b/pkg/analysis/passes/org/org.go
@@ -10,10 +10,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/grafana"
 )
 
+var (
+	missingGrafanaCloudAccount = &analysis.Rule{Name: "missing-grafanacloud-account"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "org",
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{missingGrafanaCloudAccount},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -40,10 +45,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	_, err := client.FindOrgBySlug(username)
 	if err != nil {
 		if err == grafana.ErrOrganizationNotFound {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Error,
-				Message:  fmt.Sprintf("unregistered Grafana Cloud account: %s", username),
-			})
+			pass.Reportf(missingGrafanaCloudAccount, fmt.Sprintf("unregistered Grafana Cloud account: %s", username))
 		} else if err == grafana.ErrPrivateOrganization {
 			return nil, nil
 		}

--- a/pkg/analysis/passes/pluginname/pluginname.go
+++ b/pkg/analysis/passes/pluginname/pluginname.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 )
 
+var (
+	humanFriendlyName = &analysis.Rule{Name: "human-friendly-name"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "pluginname",
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{humanFriendlyName},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -22,11 +27,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if data.ID != "" && data.Name != "" && data.ID == data.Name {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "plugin name should be human-friendly",
-			Context:  "plugin.json",
-		})
+		pass.Reportf(humanFriendlyName, "plugin.json: plugin name should be human-friendly")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/readme/readme.go
+++ b/pkg/analysis/passes/readme/readme.go
@@ -9,10 +9,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 )
 
+var (
+	missingReadme = &analysis.Rule{Name: "missing-readme"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "readme",
 	Run:      run,
 	Requires: []*analysis.Analyzer{archive.Analyzer},
+	Rules:    []*analysis.Rule{missingReadme},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -21,10 +26,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := ioutil.ReadFile(filepath.Join(archiveDir, "README.md"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Error,
-				Message:  "missing README.md",
-			})
+			pass.Reportf(missingReadme, "missing README.md")
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/analysis/passes/restrictivedep/restrictivedep.go
+++ b/pkg/analysis/passes/restrictivedep/restrictivedep.go
@@ -10,10 +10,16 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 )
 
+var (
+	dependsOnPatchReleases = &analysis.Rule{Name: "depends-on-patch-releases"}
+	dependsOnSingleRelease = &analysis.Rule{Name: "depends-on-single-release"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "restrictivedep",
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{dependsOnPatchReleases, dependsOnSingleRelease},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -34,20 +40,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	if regexp.MustCompile("^[0-9]+.[0-9]+.x$").Match([]byte(data.Dependencies.GrafanaDependency)) {
 		version := strings.TrimSuffix(data.Dependencies.GrafanaDependency, ".x")
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  fmt.Sprintf("plugin only targets patch releases of Grafana %s", version),
-			Context:  "plugin.json",
-		})
+		pass.Reportf(dependsOnPatchReleases, fmt.Sprintf("plugin.json: plugin only targets patch releases of Grafana %s", version))
 		return nil, nil
 	}
 
 	if regexp.MustCompile("^[0-9]+.[0-9]+.[0-9]+$").Match([]byte(data.Dependencies.GrafanaDependency)) {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  fmt.Sprintf("plugin only targets Grafana %s", data.Dependencies.GrafanaDependency),
-			Context:  "plugin.json",
-		})
+		pass.Reportf(dependsOnSingleRelease, fmt.Sprintf("plugin.json: plugin only targets Grafana %s", data.Dependencies.GrafanaDependency))
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/screenshots/screenshots.go
+++ b/pkg/analysis/passes/screenshots/screenshots.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 )
 
+var (
+	screenshots = &analysis.Rule{Name: "screenshots"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "screenshots",
 	Run:      checkScreenshotsExist,
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
+	Rules:    []*analysis.Rule{screenshots},
 }
 
 func checkScreenshotsExist(pass *analysis.Pass) (interface{}, error) {
@@ -22,11 +27,7 @@ func checkScreenshotsExist(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if len(data.Info.Screenshots) == 0 {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "should include screenshots for marketplace",
-			Context:  "plugin.json",
-		})
+		pass.Reportf(screenshots, "plugin.json: should include screenshots for marketplace")
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/templatereadme/templatereadme.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 )
 
+var (
+	templateReadme = &analysis.Rule{Name: "template-readme"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "templatereadme",
 	Requires: []*analysis.Analyzer{readme.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{templateReadme},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -19,11 +24,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	re := regexp.MustCompile("^# Grafana (Panel|Data Source|Data Source Backend) Plugin Template")
 
 	if m := re.Find(readme); m != nil {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Warning,
-			Message:  "uses README from template",
-			Context:  "README.md",
-		})
+		pass.Reportf(templateReadme, "README.md: uses README from template")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -7,10 +7,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
 )
 
+var (
+	trackingScripts = &analysis.Rule{Name: "tracking-scripts"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "trackingscripts",
 	Requires: []*analysis.Analyzer{modulejs.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{trackingScripts},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -24,11 +29,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	for _, url := range servers {
 		if bytes.Contains(module, []byte(url)) {
-			pass.Report(analysis.Diagnostic{
-				Severity: analysis.Warning,
-				Message:  "should not include tracking scripts",
-				Context:  "module.js",
-			})
+			pass.Reportf(trackingScripts, "module.js: should not include tracking scripts")
 			break
 		}
 	}

--- a/pkg/analysis/passes/typesuffix/typesuffix.go
+++ b/pkg/analysis/passes/typesuffix/typesuffix.go
@@ -8,10 +8,15 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 )
 
+var (
+	pluginTypeSuffix = &analysis.Rule{Name: "plugin-type-suffix"}
+)
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "typesuffix",
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
+	Rules:    []*analysis.Rule{pluginTypeSuffix},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -29,11 +34,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	idParts := strings.Split(data.ID, "-")
 
 	if idParts[len(idParts)-1] != data.Type {
-		pass.Report(analysis.Diagnostic{
-			Severity: analysis.Error,
-			Message:  "plugin id should end with plugin type",
-			Context:  "plugin.json",
-		})
+		pass.Reportf(pluginTypeSuffix, "plugin.json: plugin id should end with plugin type")
 	}
 
 	return nil, nil

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -118,7 +118,7 @@ func initAnalyzers(analyzers []*analysis.Analyzer, cfg Config) {
 				}
 			}
 
-			r.Enabled = ruleEnabled
+			r.Disabled = !ruleEnabled
 			r.Severity = ruleSeverity
 		}
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -6,7 +6,30 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
-func Check(analyzers []*analysis.Analyzer, dir string) ([]analysis.Diagnostic, error) {
+type Config struct {
+	Global    GlobalConfig              `yaml:"global"`
+	Analyzers map[string]AnalyzerConfig `yaml:"analyzers"`
+}
+
+type GlobalConfig struct {
+	Enabled  bool              `yaml:"enabled"`
+	Severity analysis.Severity `yaml:"severity"`
+}
+
+type AnalyzerConfig struct {
+	Enabled  *bool                 `yaml:"enabled"`
+	Severity *analysis.Severity    `yaml:"severity"`
+	Rules    map[string]RuleConfig `yaml:"rules"`
+}
+
+type RuleConfig struct {
+	Enabled  *bool              `yaml:"enabled"`
+	Severity *analysis.Severity `yaml:"severity"`
+}
+
+func Check(analyzers []*analysis.Analyzer, dir string, cfg Config) ([]analysis.Diagnostic, error) {
+	initAnalyzers(analyzers, cfg)
+
 	var diagnostics []analysis.Diagnostic
 
 	pass := &analysis.Pass{
@@ -62,4 +85,41 @@ func Check(analyzers []*analysis.Analyzer, dir string) ([]analysis.Diagnostic, e
 	}
 
 	return diagnostics, nil
+}
+
+func initAnalyzers(analyzers []*analysis.Analyzer, cfg Config) {
+	for _, a := range analyzers {
+		// Inherit global config
+		analyzerEnabled := cfg.Global.Enabled
+		analyzerSeverity := cfg.Global.Severity
+
+		acfg, ok := cfg.Analyzers[a.Name]
+		if ok {
+			if acfg.Enabled != nil {
+				analyzerEnabled = *acfg.Enabled
+			}
+			if acfg.Severity != nil {
+				analyzerSeverity = *acfg.Severity
+			}
+		}
+
+		for _, r := range a.Rules {
+			// Inherit analyzer config
+			ruleEnabled := analyzerEnabled
+			ruleSeverity := analyzerSeverity
+
+			rcfg, ok := acfg.Rules[r.Name]
+			if ok {
+				if rcfg.Enabled != nil {
+					ruleEnabled = *rcfg.Enabled
+				}
+				if rcfg.Severity != nil {
+					ruleSeverity = *rcfg.Severity
+				}
+			}
+
+			r.Enabled = ruleEnabled
+			r.Severity = ruleSeverity
+		}
+	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -23,12 +23,12 @@ var tests = []struct {
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
 		"unsigned plugin",
-		"should include screenshots for marketplace",
-		"(root): type is required",
-		"(root): name is required",
-		"(root): id is required",
-		"(root): info is required",
-		"(root): dependencies is required",
+		"plugin.json: should include screenshots for marketplace",
+		"plugin.json: (root): type is required",
+		"plugin.json: (root): name is required",
+		"plugin.json: (root): id is required",
+		"plugin.json: (root): info is required",
+		"plugin.json: (root): dependencies is required",
 	}},
 }
 
@@ -37,7 +37,7 @@ func TestRunner(t *testing.T) {
 		t.Run(tt.Dir, func(t *testing.T) {
 			archiveDir := filepath.Join("testdata", tt.Dir)
 
-			ds, err := Check(passes.Analyzers, archiveDir)
+			ds, err := Check(passes.Analyzers, archiveDir, Config{Global: GlobalConfig{Enabled: true}})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -106,7 +106,7 @@ func TestLinearDependencies(t *testing.T) {
 		},
 	}
 
-	_, _ = Check([]*analysis.Analyzer{fourth}, "")
+	_, _ = Check([]*analysis.Analyzer{fourth}, "", Config{Global: GlobalConfig{Enabled: true}})
 
 	if len(res) != 4 {
 		t.Fatal("unexpected results")
@@ -140,7 +140,7 @@ func TestSharedParent(t *testing.T) {
 		},
 	}
 
-	_, _ = Check([]*analysis.Analyzer{firstChild, secondChild}, "")
+	_, _ = Check([]*analysis.Analyzer{firstChild, secondChild}, "", Config{Global: GlobalConfig{Enabled: true}})
 
 	if len(res) != 3 {
 		t.Fatal("unexpected results")
@@ -174,7 +174,7 @@ func TestCachedRun(t *testing.T) {
 		},
 	}
 
-	_, _ = Check([]*analysis.Analyzer{parent, firstChild, secondChild, firstChild, secondChild, parent}, "")
+	_, _ = Check([]*analysis.Analyzer{parent, firstChild, secondChild, firstChild, secondChild, parent}, "", Config{Global: GlobalConfig{Enabled: true}})
 
 	if len(res) != 3 {
 		t.Fatal("unexpected results", res)


### PR DESCRIPTION
plugincheck2 now accepts a yaml config to enable/disable analyzers and rules within them.

The major additions are:

- `pass.Reportf` takes a reference to the rule it reports and only reports the diagnostic if it's been enabled
- `initAnalyzers` configures the rules by updating the global variables in each analyzer package. Not proud of this one (a little ashamed in fact). 

Also, we should finalize the names of analyzers and rules to avoid breaking people's configs.