### PR TITLE
Fix tests by adding missing error messages

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -30,6 +30,8 @@ var tests = []struct {
 		"plugin.json: (root): id is required",
 		"plugin.json: (root): info is required",
 		"plugin.json: (root): dependencies is required",
+		"plugin.json: invalid empty small logo path",
+		"plugin.json: invalid empty large logo path",
 	}},
 }
 


### PR DESCRIPTION
`mage test:verbose` was not running because of these missing validations.