### PR TITLE
Adjust error severity types on each validator

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -196,6 +196,6 @@ func (Run) V2Local(ctx context.Context, path string) error {
 	return sh.RunV(
 		"./bin/"+runtime.GOOS+"_"+runtime.GOARCH+"/plugincheck2",
 		"-config",
-		"config/default.yaml",
+		"config/pipeline.yaml",
 		path)
 }

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1,0 +1,4 @@
+global:
+  enabled: true
+  jsonOutput: false
+  reportAll: false

--- a/pkg/analysis/passes/archive/archive.go
+++ b/pkg/analysis/passes/archive/archive.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	emptyArchive   = &analysis.Rule{Name: "empty-archive"}
-	moreThanOneDir = &analysis.Rule{Name: "more-than-one-dir"}
-	noRootDir      = &analysis.Rule{Name: "no-root-dir"}
-	dist           = &analysis.Rule{Name: "dist"}
+	emptyArchive   = &analysis.Rule{Name: "empty-archive", Severity: analysis.Error}
+	moreThanOneDir = &analysis.Rule{Name: "more-than-one-dir", Severity: analysis.Error}
+	noRootDir      = &analysis.Rule{Name: "no-root-dir", Severity: analysis.Error}
+	dist           = &analysis.Rule{Name: "dist", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/archivename/archivename.go
+++ b/pkg/analysis/passes/archivename/archivename.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	noIdentRootDir = &analysis.Rule{Name: "no-ident-root-dir"}
+	noIdentRootDir = &analysis.Rule{Name: "no-ident-root-dir", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/brokenlinks/brokenlinks.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	relativeLink = &analysis.Rule{Name: "relative-link"}
-	brokenLink   = &analysis.Rule{Name: "broken-link"}
+	relativeLink = &analysis.Rule{Name: "relative-link", Severity: analysis.Error}
+	brokenLink   = &analysis.Rule{Name: "broken-link", Severity: analysis.Warning}
 )
 
 var mdLinks = regexp.MustCompile(`\[.+?\]\((.+?)\)`)

--- a/pkg/analysis/passes/htmlreadme/htmlreadme.go
+++ b/pkg/analysis/passes/htmlreadme/htmlreadme.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	noHTMLReadme = &analysis.Rule{Name: "no-html-readme"}
+	noHTMLReadme = &analysis.Rule{Name: "no-html-readme", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/jargon/jargon.go
+++ b/pkg/analysis/passes/jargon/jargon.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	developerJargon = &analysis.Rule{Name: "developer-jargon"}
+	developerJargon = &analysis.Rule{Name: "developer-jargon", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	legacyPlatform = &analysis.Rule{Name: "legacy-platform"}
+	legacyPlatform = &analysis.Rule{Name: "legacy-platform", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/logos/logos.go
+++ b/pkg/analysis/passes/logos/logos.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	logos = &analysis.Rule{Name: "logos"}
+	logos = &analysis.Rule{Name: "logos", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	unsignedPlugin = &analysis.Rule{Name: "unsigned-plugin"}
+	unsignedPlugin = &analysis.Rule{Name: "unsigned-plugin", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -26,7 +26,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := ioutil.ReadFile(filepath.Join(archiveDir, "MANIFEST.txt"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "unsigned plugin", "MANIFEST.txt file not found. Please refer to the documentation for how to sign a plugin.")
+			pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "unsigned plugin", "MANIFEST.txt file not found. Please refer to the documentation for how to sign a plugin. https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/")
 			return nil, nil
 		} else {
 			if unsignedPlugin.ReportAll {

--- a/pkg/analysis/passes/metadata/metadata.go
+++ b/pkg/analysis/passes/metadata/metadata.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	missingMetadata = &analysis.Rule{Name: "missing-metadata"}
+	missingMetadata = &analysis.Rule{Name: "missing-metadata", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/metadatapaths/metadatapaths.go
+++ b/pkg/analysis/passes/metadatapaths/metadatapaths.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	invalidPath            = &analysis.Rule{Name: "invalid-path"}
-	pathRelativeToMetadata = &analysis.Rule{Name: "path-relative-to-metadata"}
-	invalidRelativePath    = &analysis.Rule{Name: "invalid-relative-path"}
-	pathNotExists          = &analysis.Rule{Name: "path-not-exists"}
+	invalidPath            = &analysis.Rule{Name: "invalid-path", Severity: analysis.Error}
+	pathRelativeToMetadata = &analysis.Rule{Name: "path-relative-to-metadata", Severity: analysis.Error}
+	invalidRelativePath    = &analysis.Rule{Name: "invalid-relative-path", Severity: analysis.Error}
+	pathNotExists          = &analysis.Rule{Name: "path-not-exists", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/metadatavalid/metadatavalid.go
+++ b/pkg/analysis/passes/metadatavalid/metadatavalid.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	invalidMetadata = &analysis.Rule{Name: "invalid-metadata"}
+	invalidMetadata = &analysis.Rule{Name: "invalid-metadata", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -64,7 +64,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	for _, desc := range result.Errors() {
-		pass.ReportResult(pass.AnalyzerName, invalidMetadata, fmt.Sprintf("plugin.json: %s: %s", desc.Field(), desc.Description()), "The plugin.json file is not following the schema. Please refer to the documentation for more information.")
+		pass.ReportResult(pass.AnalyzerName, invalidMetadata, fmt.Sprintf("plugin.json: %s: %s", desc.Field(), desc.Description()), "The plugin.json file is not following the schema. Please refer to the documentation for more information. https://grafana.com/docs/grafana/latest/developers/plugins/metadata/")
 	}
 	if len(result.Errors()) == 0 && invalidMetadata.ReportAll {
 		invalidMetadata.Severity = analysis.OK

--- a/pkg/analysis/passes/modulejs/modulejs.go
+++ b/pkg/analysis/passes/modulejs/modulejs.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	missingModulejs = &analysis.Rule{Name: "missing-modulejs"}
+	missingModulejs = &analysis.Rule{Name: "missing-modulejs", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/org/org.go
+++ b/pkg/analysis/passes/org/org.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	missingGrafanaCloudAccount = &analysis.Rule{Name: "missing-grafanacloud-account"}
+	missingGrafanaCloudAccount = &analysis.Rule{Name: "missing-grafanacloud-account", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/pluginname/pluginname.go
+++ b/pkg/analysis/passes/pluginname/pluginname.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	humanFriendlyName = &analysis.Rule{Name: "human-friendly-name"}
+	humanFriendlyName = &analysis.Rule{Name: "human-friendly-name", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/readme/readme.go
+++ b/pkg/analysis/passes/readme/readme.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	missingReadme = &analysis.Rule{Name: "missing-readme"}
+	missingReadme = &analysis.Rule{Name: "missing-readme", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/restrictivedep/restrictivedep.go
+++ b/pkg/analysis/passes/restrictivedep/restrictivedep.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	dependsOnPatchReleases = &analysis.Rule{Name: "depends-on-patch-releases"}
-	dependsOnSingleRelease = &analysis.Rule{Name: "depends-on-single-release"}
+	dependsOnPatchReleases = &analysis.Rule{Name: "depends-on-patch-releases", Severity: analysis.Warning}
+	dependsOnSingleRelease = &analysis.Rule{Name: "depends-on-single-release", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/screenshots/screenshots.go
+++ b/pkg/analysis/passes/screenshots/screenshots.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	screenshots = &analysis.Rule{Name: "screenshots"}
+	screenshots = &analysis.Rule{Name: "screenshots", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/signature/signature.go
+++ b/pkg/analysis/passes/signature/signature.go
@@ -21,10 +21,10 @@ import (
 )
 
 var (
-	unsignedPlugin    = &analysis.Rule{Name: "unsigned-plugin"}
-	modifiedSignature = &analysis.Rule{Name: "modified-signature"}
-	invalidSignature  = &analysis.Rule{Name: "invalid-signature"}
-	privateSignature  = &analysis.Rule{Name: "private-signature"}
+	unsignedPlugin    = &analysis.Rule{Name: "unsigned-plugin", Severity: analysis.Warning}
+	modifiedSignature = &analysis.Rule{Name: "modified-signature", Severity: analysis.Warning}
+	invalidSignature  = &analysis.Rule{Name: "invalid-signature", Severity: analysis.Warning}
+	privateSignature  = &analysis.Rule{Name: "private-signature", Severity: analysis.Warning}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/templatereadme/templatereadme.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	templateReadme = &analysis.Rule{Name: "template-readme"}
+	templateReadme = &analysis.Rule{Name: "template-readme", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/templatereadme/templatereadme.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme.go
@@ -21,7 +21,7 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	readme := pass.ResultOf[readme.Analyzer].([]byte)
 
-	re := regexp.MustCompile("^# Grafana (Panel|Data Source|Data Source Backend) Plugin Template")
+	re := regexp.MustCompile("(?i)Grafana (Panel|Data Source|Datasource|App|Data Source Backend) Plugin Template")
 
 	if m := re.Find(readme); m != nil {
 		pass.ReportResult(pass.AnalyzerName, templateReadme, "README.md: uses README from template", "The README.md file uses the README from the plugin template. Please update it to describe your plugin.")

--- a/pkg/analysis/passes/templatereadme/templatereadme_test.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme_test.go
@@ -26,3 +26,20 @@ func TestTemplateReadme(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "README.md: uses README from template")
 }
+
+func TestTemplateReadmeLowerCase(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	readmeContent := []byte(`# Grafana panel Plugin Template`)
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			readme.Analyzer: (readmeContent),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, interceptor.Diagnostics[0].Title, "README.md: uses README from template")
+}

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	trackingScripts = &analysis.Rule{Name: "tracking-scripts"}
+	trackingScripts = &analysis.Rule{Name: "tracking-scripts", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/typesuffix/typesuffix.go
+++ b/pkg/analysis/passes/typesuffix/typesuffix.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	pluginTypeSuffix = &analysis.Rule{Name: "plugin-type-suffix"}
+	pluginTypeSuffix = &analysis.Rule{Name: "plugin-type-suffix", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -93,36 +93,44 @@ func Check(analyzers []*analysis.Analyzer, dir string, cfg Config) (map[string][
 
 func initAnalyzers(analyzers []*analysis.Analyzer, cfg Config) {
 	for _, a := range analyzers {
-		// Inherit global config
+		// Inherit global config file
 		analyzerEnabled := cfg.Global.Enabled
 		analyzerSeverity := cfg.Global.Severity
 
+		// default to hardcoded defaultSeverity if not set
 		if analyzerSeverity == "" {
 			analyzerSeverity = defaultSeverity
 		}
 
-		acfg, ok := cfg.Analyzers[a.Name]
+		// Override via config file
+		analyzerConfig, ok := cfg.Analyzers[a.Name]
 		if ok {
-			if acfg.Enabled != nil {
-				analyzerEnabled = *acfg.Enabled
+			if analyzerConfig.Enabled != nil {
+				analyzerEnabled = *analyzerConfig.Enabled
 			}
-			if acfg.Severity != nil {
-				analyzerSeverity = *acfg.Severity
+			if analyzerConfig.Severity != nil {
+				analyzerSeverity = *analyzerConfig.Severity
 			}
 		}
 
 		for _, r := range a.Rules {
 			// Inherit analyzer config
 			ruleEnabled := analyzerEnabled
-			ruleSeverity := analyzerSeverity
 
-			rcfg, ok := acfg.Rules[r.Name]
+			// use own config if available
+			ruleSeverity := r.Severity
+			if ruleSeverity == "" {
+				ruleSeverity = analyzerSeverity
+			}
+
+			// overwrite via config file
+			ruleConfig, ok := analyzerConfig.Rules[r.Name]
 			if ok {
-				if rcfg.Enabled != nil {
-					ruleEnabled = *rcfg.Enabled
+				if ruleConfig.Enabled != nil {
+					ruleEnabled = *ruleConfig.Enabled
 				}
-				if rcfg.Severity != nil {
-					ruleSeverity = *rcfg.Severity
+				if ruleConfig.Severity != nil {
+					ruleSeverity = *ruleConfig.Severity
 				}
 			}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -29,6 +29,8 @@ type RuleConfig struct {
 	Severity *analysis.Severity `yaml:"severity"`
 }
 
+var defaultSeverity = analysis.Warning
+
 func Check(analyzers []*analysis.Analyzer, dir string, cfg Config) (map[string][]analysis.Diagnostic, error) {
 	initAnalyzers(analyzers, cfg)
 	diagnostics := make(map[string][]analysis.Diagnostic)
@@ -94,6 +96,10 @@ func initAnalyzers(analyzers []*analysis.Analyzer, cfg Config) {
 		// Inherit global config
 		analyzerEnabled := cfg.Global.Enabled
 		analyzerSeverity := cfg.Global.Severity
+
+		if analyzerSeverity == "" {
+			analyzerSeverity = defaultSeverity
+		}
 
 		acfg, ok := cfg.Analyzers[a.Name]
 		if ok {


### PR DESCRIPTION
- Use a default severity to warning if none is passed
- Allow rules to define their own severity and use them if not overwritten by config
- Adding default severities for all passes


Note to reviewer: Even though they seem to be many file changes they are repetitive.