### PR TITLE
sourcecode: Ignore checks if sourceCodeUri is not provided

### DIFF
--- a/pkg/analysis/passes/sourcecode/sourcecode.go
+++ b/pkg/analysis/passes/sourcecode/sourcecode.go
@@ -35,7 +35,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	sourceCodeDir := pass.SourceCodeDir
 	if sourceCodeDir == "" {
-		pass.ReportResult(pass.AnalyzerName, sourceCodeNotProvided, fmt.Sprintf("Sourcecode not provided or the provided URL %s does not point to a valid source code repository", pass.SourceCodeDir), "If you are passing a Git ref or sub-directory in the URL make sure they are correct.")
+		// Silently skip check if no source code is provided, for backwards compatibility
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/sourcecode/sourcecode.go
+++ b/pkg/analysis/passes/sourcecode/sourcecode.go
@@ -35,7 +35,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	sourceCodeDir := pass.SourceCodeDir
 	if sourceCodeDir == "" {
-		// Silently skip check if no source code is provided, for backwards compatibility
+		// If no source code dir is provided, only report the result if ReportAll is set, for backwards compatibility
+		if sourceCodeNotProvided.ReportAll {
+			pass.ReportResult(pass.AnalyzerName, sourceCodeNotProvided, fmt.Sprintf("Sourcecode not provided or the provided URL %s does not point to a valid source code repository", pass.SourceCodeDir), "If you are passing a Git ref or sub-directory in the URL make sure they are correct.")
+		}
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/sourcecode/sourcecode_test.go
+++ b/pkg/analysis/passes/sourcecode/sourcecode_test.go
@@ -12,6 +12,18 @@ import (
 
 const pluginId = "test-plugin-panel"
 
+func reportAll(a *analysis.Analyzer) {
+	for _, r := range a.Rules {
+		r.ReportAll = true
+	}
+}
+
+func undoReportAll(a *analysis.Analyzer) {
+	for _, r := range a.Rules {
+		r.ReportAll = false
+	}
+}
+
 func TestSourceCodeNotProvided(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pluginJsonContent := []byte(`{
@@ -34,6 +46,38 @@ func TestSourceCodeNotProvided(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, interceptor.Diagnostics, 0)
+	require.Equal(t, nil, sourceCodeDir)
+}
+
+func TestSourceCodeNotProvidedReportAll(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pluginJsonContent := []byte(`{
+		"id": "` + pluginId + `",
+		"type": "panel",
+		"info": {
+			"version": "2.1.2"
+		}
+	}`)
+	pass := &analysis.Pass{
+		RootDir:       filepath.Join("./"),
+		SourceCodeDir: "",
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer: pluginJsonContent,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	// Turn on ReportAll for all rules, then turn it back off at the end of the test
+	reportAll(Analyzer)
+	t.Cleanup(func() {
+		undoReportAll(Analyzer)
+	})
+
+	sourceCodeDir, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "Sourcecode not provided or the provided URL  does not point to a valid source code repository", interceptor.Diagnostics[0].Title)
 	require.Equal(t, nil, sourceCodeDir)
 }
 

--- a/pkg/analysis/passes/sourcecode/sourcecode_test.go
+++ b/pkg/analysis/passes/sourcecode/sourcecode_test.go
@@ -33,10 +33,8 @@ func TestSourceCodeNotProvided(t *testing.T) {
 	sourceCodeDir, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "Sourcecode not provided or the provided URL  does not point to a valid source code repository", interceptor.Diagnostics[0].Title)
+	require.Len(t, interceptor.Diagnostics, 0)
 	require.Equal(t, nil, sourceCodeDir)
-
 }
 
 func TestVersionSourceCodeMatch(t *testing.T) {

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -169,8 +169,8 @@ func readConfigFile(path string) (runner.Config, error) {
 }
 
 func getSourceCodeDir(sourceCodeUri string) (string, func(), error) {
-	// If no source code URI is provided, return immediately with an empty string
-	// otherwise we will get an error
+	// If source code URI is not provided, return immediately with an empty string
+	// otherwise we will get an error when trying to extract the source code archive
 	if sourceCodeUri == "" {
 		return "", func() {}, nil
 	}

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -169,6 +169,12 @@ func readConfigFile(path string) (runner.Config, error) {
 }
 
 func getSourceCodeDir(sourceCodeUri string) (string, func(), error) {
+	// If no source code URI is provided, return immediately with an empty string
+	// otherwise we will get an error
+	if sourceCodeUri == "" {
+		return "", func() {}, nil
+	}
+
 	// file:// protocol for local directories
 	if strings.HasPrefix(sourceCodeUri, "file://") {
 		sourceCodeDir := strings.TrimPrefix(sourceCodeUri, "file://")

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -35,7 +35,6 @@ var tests = []struct {
 		"plugin.json: invalid empty large logo path",
 		"License not found",
 		"Plugin version \"\" is invalid.",
-		"Sourcecode not provided or the provided URL  does not point to a valid source code repository",
 	}},
 }
 


### PR DESCRIPTION
This PR ensures the validator does not print warnings if the `sourceCodeUri` CLI argument is not provided.

This would be ideal because the workflow in our template does not have `-sourceCodeUri`:

https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/github/ci/.github/workflows/release.yml#L108

The current output is:
```
couldn't get source code: couldn't extract source code archive: . open : no such file or directory
warning: Sourcecode not provided or the provided URL does not point to a valid source code repository
detail: If you are passing a Git ref or sub-directory in the URL make sure they are correct. 
```

plugincheck2 exits with code 0, so the check does not fail, but it is confusing for the user.

Another solution would be adding `-sourceCodeUri file://.` to the plugincheck2 command inside the GitHub workflow, however that won't affect existing plugins.

Alternative solutions are welcome!