### PR TITLE
Add Published plugin validator for later validation checks

### DIFF
--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/org"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/pluginname"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/published"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/restrictivedep"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/screenshots"
@@ -52,6 +53,7 @@ var Analyzers = []*analysis.Analyzer{
 	modulejs.Analyzer,
 	org.Analyzer,
 	pluginname.Analyzer,
+	published.Analyzer,
 	readme.Analyzer,
 	restrictivedep.Analyzer,
 	screenshots.Analyzer,

--- a/pkg/analysis/passes/pluginname/pluginname_test.go
+++ b/pkg/analysis/passes/pluginname/pluginname_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/published"
 	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
 	"github.com/stretchr/testify/require"
 )
@@ -13,10 +14,18 @@ import (
 func TestValidPluginName(t *testing.T) {
 	const pluginId = "raintank-plugin-panel"
 	var interceptor testpassinterceptor.TestPassInterceptor
+
+	publishedStatus := &published.PluginStatus{
+		Status:  "active",
+		Version: "1.0.0",
+		Slug:    pluginId,
+	}
+
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			metadata.Analyzer: []byte(`{"ID": "` + pluginId + `", "name": "my plugin name", "info": {"logos": {"large": "img/logo.svg"}}}`),
+			metadata.Analyzer:  []byte(`{"ID": "` + pluginId + `", "name": "my plugin name", "info": {"logos": {"large": "img/logo.svg"}}}`),
+			published.Analyzer: publishedStatus,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -29,10 +38,12 @@ func TestValidPluginName(t *testing.T) {
 func TestInvalidPluginName(t *testing.T) {
 	const pluginId = "raintank-plugin-panel"
 	var interceptor testpassinterceptor.TestPassInterceptor
+
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			metadata.Analyzer: []byte(`{"ID": "` + pluginId + `", "name": "` + pluginId + `", "info": {"logos": {"large": "img/logo.svg"}}}`),
+			metadata.Analyzer:  []byte(`{"ID": "` + pluginId + `", "name": "` + pluginId + `", "info": {"logos": {"large": "img/logo.svg"}}}`),
+			published.Analyzer: nil,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}

--- a/pkg/analysis/passes/published/published.go
+++ b/pkg/analysis/passes/published/published.go
@@ -40,7 +40,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	defer cancelContext()
 	pluginStatus, err := getPluginDataFromGrafanaCom(context, data.ID)
 	if err != nil {
-		fmt.Println("I am here")
 		// in case of any error getting the online status, skip this check
 		return nil, nil
 	}

--- a/pkg/analysis/passes/published/published.go
+++ b/pkg/analysis/passes/published/published.go
@@ -1,0 +1,80 @@
+package published
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "published-plugin",
+	Requires: []*analysis.Analyzer{metadata.Analyzer},
+	Run:      run,
+	Rules:    []*analysis.Rule{},
+}
+
+type PluginStatus struct {
+	Status  string `json:"status"`
+	Slug    string `json:"slug"`
+	Version string `json:"version"`
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+	var data metadata.Metadata
+	if err := json.Unmarshal(metadataBody, &data); err != nil {
+		return nil, err
+	}
+
+	// 15 seconds timeout to fetch data from grafana API
+	context, cancelContext := context.WithTimeout(context.Background(), time.Second*15)
+	defer cancelContext()
+	pluginStatus, err := getPluginDataFromGrafanaCom(context, data.ID)
+	if err != nil {
+		fmt.Println("I am here")
+		// in case of any error getting the online status, skip this check
+		return nil, nil
+	}
+
+	return pluginStatus, nil
+}
+
+func getPluginDataFromGrafanaCom(context context.Context, pluginId string) (*PluginStatus, error) {
+	pluginUrl := fmt.Sprintf("https://grafana.com/api/plugins/%s?version=latest", pluginId)
+	// fetch content for pluginUrl
+	request, err := http.NewRequestWithContext(context, "GET", pluginUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Accept", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	// 404 = the plugin is not yet published
+	if response.StatusCode == http.StatusNotFound {
+		return nil, errors.New("plugin not found")
+	}
+
+	// != 200 = something went wrong. We can't check the plugin
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("wrong status code, expected 200 got %d", response.StatusCode)
+	}
+
+	status := PluginStatus{}
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}

--- a/pkg/analysis/passes/published/published_test.go
+++ b/pkg/analysis/passes/published/published_test.go
@@ -1,0 +1,122 @@
+package published
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+const testPluginId = "test-plugin-panel"
+
+func getMockVersionResponse(id string, version string) string {
+	content := fmt.Sprintf(`
+	{
+  	"status": "active",
+  	"id": 31,
+  	"typeId": 3,
+  	"typeName": "Panel",
+  	"typeCode": "panel",
+  	"slug": "%s",
+  	"name": "Clock",
+  	"description": "Clock panel for grafana",
+  	"version": "%s",
+  	"orgName": "Grafana Labs",
+  	"orgSlug": "grafana",
+  	"orgUrl": "https://grafana.org",
+  	"url": "https://github.com/grafana/clock-panel/",
+  	"createdAt": "2016-03-31T13:09:33.000Z",
+  	"updatedAt": "2023-01-04T10:24:26.000Z"
+  }
+	`, id, version)
+	return content
+}
+
+func setupTestAnalyzer(pluginGrafanaComVersion string) (*analysis.Pass, *testpassinterceptor.TestPassInterceptor, func()) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+
+	httpmock.Activate()
+
+	responseContent := getMockVersionResponse(testPluginId, pluginGrafanaComVersion)
+	responseCode := http.StatusOK
+
+	// mock grafana.com response
+	pluginUrl := fmt.Sprintf("https://grafana.com/api/plugins/%s?version=latest", testPluginId)
+	httpmock.RegisterResponder("GET", pluginUrl,
+		httpmock.NewStringResponder(responseCode, responseContent))
+
+	pluginJsonContent := []byte(`{
+		"id": "` + testPluginId + `",
+		"type": "panel",
+		"executable": "test-plugin-panel",
+		"info": {
+			"version": "` + pluginGrafanaComVersion + `"
+		}
+	}`)
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer: pluginJsonContent,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+	return pass, &interceptor, httpmock.DeactivateAndReset
+}
+
+// an unpublished plugin should simply skip this check by
+// returning nil and no errors
+func TestUnpublishedPlugin(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	pass, interceptor, cleanup := setupTestAnalyzer("1.0.0")
+	defer cleanup()
+
+	// mock unpublished plugin
+	responseContent := `{
+  	"code": "NotFound",
+  	"message": "plugin not found",
+  	"requestId": "mock-test-id"
+	}`
+	responseCode := http.StatusNotFound
+
+	// mock grafana.com response
+	pluginUrl := fmt.Sprintf("https://grafana.com/api/plugins/%s?version=latest", testPluginId)
+	httpmock.RegisterResponder("GET", pluginUrl,
+		httpmock.NewStringResponder(responseCode, responseContent))
+
+	analyzerResult, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.Len(t, httpmock.GetCallCountInfo(), 1)
+	require.Len(t, interceptor.Diagnostics, 0)
+	require.Nil(t, analyzerResult)
+}
+
+func TestPublishedPlugin(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	pass, interceptor, cleanup := setupTestAnalyzer("1.0.0")
+	defer cleanup()
+
+	analyzerResult, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	expectedStatus := &PluginStatus{
+		Status:  "active",
+		Slug:    "test-plugin-panel",
+		Version: "1.0.0",
+	}
+
+	require.Len(t, httpmock.GetCallCountInfo(), 1)
+	require.Len(t, interceptor.Diagnostics, 0)
+	require.Equal(t, analyzerResult, expectedStatus)
+}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -34,7 +34,6 @@ var tests = []struct {
 		"plugin.json: invalid empty small logo path",
 		"plugin.json: invalid empty large logo path",
 		"LICENSE file not found",
-		"Plugin version \"\" is invalid.",
 	}},
 }
 


### PR DESCRIPTION
- Add published version validator and replace its usage in version validator
- This validator contains the logic to see if a plugin is published and which version
- Skip human friendly names checks if the plugin is already published

Closes https://github.com/grafana/plugin-validator/issues/72