### PR TITLE
Fail plugins using angularjs

### DIFF
--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -36,7 +36,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
-	if !ok || moduleJsMap == nil {
+	if !ok || len(moduleJsMap) == 0 {
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -21,7 +21,7 @@ var Analyzer = &analysis.Analyzer{
 
 var legacyDetectionRegexes = []*regexp.Regexp{
 	// regexp.MustCompile(`['"](app/core/.*?)|(app/plugins/.*?)['"]`),
-	regexp.MustCompile(`['"](app/core/utils/promiseToDigest)|(app/plugins/.*?)|(app/core/core_module)|(app/core/core_module)|(app/core/core)['"]`),
+	regexp.MustCompile(`['"](app/core/utils/promiseToDigest)|(app/plugins/.*?)|(app/core/core_module)['"]`),
 	regexp.MustCompile(`from\s+['"]grafana\/app\/`),
 	regexp.MustCompile(`System\.register\(`),
 }

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -35,14 +35,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		legacyPlatform.Severity = analysis.Warning
 	}
 
-	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(*map[string][]byte)
+	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
 	if !ok || moduleJsMap == nil {
 		return nil, nil
 	}
 
 	hasLegacyPlatform := false
 
-	for _, content := range *moduleJsMap {
+	for _, content := range moduleJsMap {
 		if hasLegacyPlatform {
 			break
 		}

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -5,34 +5,51 @@ import (
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
 )
 
 var (
-	legacyPlatform = &analysis.Rule{Name: "legacy-platform", Severity: analysis.Warning}
+	legacyPlatform = &analysis.Rule{Name: "legacy-platform", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "legacyplatform",
-	Requires: []*analysis.Analyzer{modulejs.Analyzer},
+	Requires: []*analysis.Analyzer{modulejs.Analyzer, sourcecode.Analyzer},
 	Run:      run,
 	Rules:    []*analysis.Rule{legacyPlatform},
 }
 
+var legacyDetectionRegexes = []*regexp.Regexp{
+	// regexp.MustCompile(`['"](app/core/.*?)|(app/plugins/.*?)['"]`),
+	regexp.MustCompile(`['"](app/core/utils/promiseToDigest)|(app/plugins/.*?)|(app/core/core_module)|(app/core/core_module)|(app/core/core)['"]`),
+	regexp.MustCompile(`from\s+['"]grafana\/app\/`),
+	regexp.MustCompile(`System\.register\(`),
+}
+
 func run(pass *analysis.Pass) (interface{}, error) {
-	module := pass.ResultOf[modulejs.Analyzer].([]byte)
+	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(*map[string][]byte)
+	if !ok || moduleJsMap == nil {
+		return nil, nil
+	}
 
-	var (
-		reactExp   = regexp.MustCompile(`(@grafana/data)`)
-		angularExp = regexp.MustCompile(`([\s"']grafana/app/)`)
-	)
+	hasLegacyPlatform := false
 
-	if angularExp.Match(module) && !reactExp.Match(module) {
-		pass.ReportResult(pass.AnalyzerName, legacyPlatform, "module.js: uses legacy plugin platform", "The plugin uses the legacy plugin platform (angularjs). Please migrate the plugin to use the new plugins platform.")
-	} else {
-		if legacyPlatform.ReportAll {
-			legacyPlatform.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, legacyPlatform, "module.js: uses current plugin platform", "")
+	for _, content := range *moduleJsMap {
+		if hasLegacyPlatform {
+			break
 		}
+		for _, regex := range legacyDetectionRegexes {
+			if regex.Match(content) {
+				pass.ReportResult(pass.AnalyzerName, legacyPlatform, "module.js: uses legacy plugin platform", "The plugin uses the legacy plugin platform (e.g. angularjs). Please migrate the plugin to use the new plugins platform.")
+				hasLegacyPlatform = true
+				break
+			}
+		}
+	}
+
+	if legacyPlatform.ReportAll && !hasLegacyPlatform {
+		legacyPlatform.Severity = analysis.OK
+		pass.ReportResult(pass.AnalyzerName, legacyPlatform, "module.js: uses current plugin platform", "")
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -18,7 +18,7 @@ func TestLegacyPlatformUsesCurrentPlatform(t *testing.T) {
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: &map[string][]byte{"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`)},
+			modulejs.Analyzer: map[string][]byte{"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`)},
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -43,7 +43,7 @@ func TestLegacyPlatformUsesLegacy(t *testing.T) {
 		pass := &analysis.Pass{
 			RootDir: filepath.Join("./"),
 			ResultOf: map[*analysis.Analyzer]interface{}{
-				modulejs.Analyzer: &moduleJsMap,
+				modulejs.Analyzer: moduleJsMap,
 			},
 			Report: interceptor.ReportInterceptor(),
 		}
@@ -67,7 +67,7 @@ func TestOnlyWarnInPublishedPlugins(t *testing.T) {
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer:  &map[string][]byte{"module.js": []byte(`import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';`)},
+			modulejs.Analyzer:  map[string][]byte{"module.js": []byte(`import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';`)},
 			published.Analyzer: &pluginStatus,
 		},
 		Report: interceptor.ReportInterceptor(),

--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -17,7 +17,7 @@ func TestLegacyPlatformUsesCurrentPlatform(t *testing.T) {
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: []byte(`import { PanelPlugin } from '@grafana/data'`),
+			modulejs.Analyzer: &map[string][]byte{"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`)},
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -27,18 +27,31 @@ func TestLegacyPlatformUsesCurrentPlatform(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 0)
 }
 
+var legacyImportTests = []map[string][]byte{
+	{"module.js": []byte(`import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';`)},
+	{"module.js": []byte(`define(["app/plugins/sdk"],(function(n){return function(n){var t={};function e(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,e),o.l=!0,o.exports}return e.m=n,e.c=t,e.d=function(n,t,r){e.o(n,t)||Object.defineProperty(n,t,{enumerable:!0,get:r})},e.r=function(n){"undefined"!=typeof`)},
+	{"module.js": []byte(`define(["app/plugins/sdk"],(function(n){return function(n){var t={};function e(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,e),o.l=!0,o.exports}return e.m=n,e.c=t,e.d=function(n,t,r){e.o(n,t)||Object.defineProperty(n,t,{enumerable:!0,get:r})},e.r=function(n){"undefined"!=typeof Symbol&&Symbol.toSt`)},
+	{"module.js": []byte(`define(["react","lodash","@grafana/data","@grafana/ui","@emotion/css","@grafana/runtime","moment","app/core/utils/datemath","jquery","app/plugins/sdk","app/core/core_module","app/core/core","app/core/table_model","app/core/utils/kbn","app/core/config","angular"],(function(e,t,r,n,i,a,o,s,u,l,c,p,f,h,d,m){return function(e){var t={};function r(n){if(t[n])return t[n].exports;var i=t[n]={i:n,l:!1,exports:{}};retur`)},
+}
+
 func TestLegacyPlatformUsesLegacy(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := &analysis.Pass{
-		RootDir: filepath.Join("./"),
-		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: []byte(`import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';`),
-		},
-		Report: interceptor.ReportInterceptor(),
+
+	for _, moduleJsMap := range legacyImportTests {
+		var interceptor testpassinterceptor.TestPassInterceptor
+
+		pass := &analysis.Pass{
+			RootDir: filepath.Join("./"),
+			ResultOf: map[*analysis.Analyzer]interface{}{
+				modulejs.Analyzer: &moduleJsMap,
+			},
+			Report: interceptor.ReportInterceptor(),
+		}
+
+		_, err := Analyzer.Run(pass)
+		require.NoError(t, err)
+		require.Len(t, interceptor.Diagnostics, 1)
+		require.Equal(t, interceptor.Diagnostics[0].Title, "module.js: uses legacy plugin platform")
+
 	}
 
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "module.js: uses legacy plugin platform")
 }

--- a/pkg/analysis/passes/modulejs/modulejs.go
+++ b/pkg/analysis/passes/modulejs/modulejs.go
@@ -51,5 +51,5 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		moduleJsFilesContent[moduleJsFile] = content
 	}
 
-	return &moduleJsFilesContent, nil
+	return moduleJsFilesContent, nil
 }

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -20,7 +20,7 @@ var Analyzer = &analysis.Analyzer{
 
 func run(pass *analysis.Pass) (interface{}, error) {
 
-	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(*map[string][]byte)
+	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
 	if !ok || moduleJsMap == nil {
 		return nil, nil
 	}
@@ -33,7 +33,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	hasTrackingScripts := false
 
-	for _, content := range *moduleJsMap {
+	for _, content := range moduleJsMap {
 		for _, url := range servers {
 			if bytes.Contains(content, []byte(url)) {
 				pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code.")

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -21,7 +21,7 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 
 	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
-	if !ok || moduleJsMap == nil {
+	if !ok || len(moduleJsMap) == 0 {
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -19,7 +19,11 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	module := pass.ResultOf[modulejs.Analyzer].([]byte)
+
+	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(*map[string][]byte)
+	if !ok || moduleJsMap == nil {
+		return nil, nil
+	}
 
 	servers := []string{
 		"https://www.google-analytics.com",
@@ -28,11 +32,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	hasTrackingScripts := false
-	for _, url := range servers {
-		if bytes.Contains(module, []byte(url)) {
-			pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code.")
-			hasTrackingScripts = true
-			break
+
+	for _, content := range *moduleJsMap {
+		for _, url := range servers {
+			if bytes.Contains(content, []byte(url)) {
+				pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code.")
+				hasTrackingScripts = true
+				break
+			}
 		}
 	}
 

--- a/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
@@ -12,10 +12,13 @@ import (
 
 func TestTrackingScriptsValid(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
+	var moduleJsMap = map[string][]byte{
+		"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`),
+	}
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: []byte(`import { PanelPlugin } from '@grafana/data'`),
+			modulejs.Analyzer: &moduleJsMap,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -27,10 +30,13 @@ func TestTrackingScriptsValid(t *testing.T) {
 
 func TestTrackingScriptsInvalid(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
+	var moduleJsMap = map[string][]byte{
+		"module.js": []byte(`https://www.google-analytics.com/analytics.js`),
+	}
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: []byte(`https://www.google-analytics.com/analytics.js`),
+			modulejs.Analyzer: &moduleJsMap,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}

--- a/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
@@ -18,7 +18,7 @@ func TestTrackingScriptsValid(t *testing.T) {
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: &moduleJsMap,
+			modulejs.Analyzer: moduleJsMap,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -36,7 +36,7 @@ func TestTrackingScriptsInvalid(t *testing.T) {
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: &moduleJsMap,
+			modulejs.Analyzer: moduleJsMap,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}


### PR DESCRIPTION
- Modulejs now reports all nested modulejs files
- Tracking scripts handles nested modulejs files
- Update regex and tests for legacy platform check. 
- Legacy platform set to error if the plugin is not published.

Solves https://github.com/grafana/plugin-validator/issues/77
