### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The tool runs a series of analyzers to ensure submitted plugins are following be
 | Broken Links / `brokenlinks` | Detects if any url does not resolve to a valid location. | None |
 | Code Rules / `coderules` | Checks for forbidden access to environment variables, file system or use of `syscall` module. | [semgrep](https://github.com/returntocorp/semgrep), `sourceCodeUri` |
 | Go Manifest / `gomanifest` | Validates the build manifest. | `sourceCodeUri` |
-| Go Security Checker / `gosec` | Inspects source code for security problems by scanning the Go AST. | [[gosec](https://github.com/securego/gosec)], `sourceCodeUri` |
+| Go Security Checker / `gosec` | Inspects source code for security problems by scanning the Go AST. | [gosec](https://github.com/securego/gosec), `sourceCodeUri` |
 | JS Source Map / `jssourcemap` | Checks for required module.js.map file(s) in archive. | `sourceCodeUri` |
 | Logos / `logos` | Detects whether the plugin includes small and large logos to display in the marketplace. | none |
 | HTML in Readme / `htmlreadme` | Detects if there are any html tags used in the README.md, as they will not render in the marketplace. | None |

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ global:
 ## Getting Help
 
 - :open_book: Check out our plugin [documentation](https://grafana.com/docs/grafana/latest/developers/plugins/).
-- See our other [Plugin Tools](https://grafana.github.io/plugin-tools/) to create and update plugins.  
+- :rocket: See our other [Plugin Tools](https://grafana.github.io/plugin-tools/) to create and update plugins.  
 - :handshake: Join the [community forum](https://community.grafana.com/tag/plugins).  
 - :speech_balloon: Chat to us in the Grafana Slack [#plugins channel](https://grafana.slack.com/archives/C3HJV5PNE).  
 - :memo: [File an issue](https://github.com/grafana/plugin-validator/issues) for any bugs or feature requests.  

--- a/README.md
+++ b/README.md
@@ -1,42 +1,49 @@
 # Grafana Plugin Validator
 
 [![License](https://img.shields.io/github/license/grafana/plugin-validator)](LICENSE)
+[![Drone](https://drone.grafana.net/api/badges/grafana/plugin-validator/status.svg)](https://drone.grafana.net/grafana/plugin-validator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/grafana/plugin-validator)](https://goreportcard.com/report/github.com/grafana/plugin-validator)
 
-A tool for validating community plugins for publishing to Grafana.com.
+The tool helps speed up the process of publishing plugins to [Grafana.com](https://grafana.com/grafana/plugins/). It runs a series of [analyzers](#analyzers) to ensure plugins are following best practices; checking for security and structural issues, as well as specific requirements related to publishing. A general overview of these requirements can be found here: <https://grafana.com/docs/grafana/latest/developers/plugins/publishing-and-signing-criteria/>.
 
-The tool expects path to either a remote or a local ZIP archive.
+It requires a path to a remote or local ZIP archive of the plugin to be specified, for example:
 
-## Install and usage
+- **Remote**: `https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip`
+- **Local**: `file://Users/me/Downloads/grafana-clock-panel-2.1.2.zip`
 
-### With docker (recommended\*)
+You can **additionally** provide a link to the source code for the project with `-sourceCodeUri` to enable additional analyzers such as the Vulnerability Scan.
+
+## Installation and usage
+
+### Docker (recommended)
+
+It is easiest to run the tool using the Docker image as it contains all the [security scanning tools](#security-tools) needed for the full set of analyzers - so you don't need to have these additional tools installed on your system.
 
 ```SHELL
-docker run --pull=always grafana/plugin-validator-cli -sourceCodeUri [source_code_location/] [plugin_archive.zip]
+docker run --pull=always grafana/plugin-validator-cli [options] [path/to/plugin_archive.zip]
 ```
 
-Example:
+#### Example 1 (basic)
+
+```SHELL
+docker run --pull=always grafana/plugin-validator-cli https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
+```
+
+#### Example 2 (specifying source code location)
 
 ```SHELL
 docker run --pull=always grafana/plugin-validator-cli -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
 ```
 
-> \* Docker is recommended because the image contains all the [security scanning tools](#security-tools) for the validator
-
-### With NPX
+### NPX
 
 ```SHELL
-npx -y @grafana/plugin-validator -sourceCodeUri [source_code_location/] [plugin_archive.zip]
-```
-
-Example:
-
-```SHELL
-npx -y @grafana/plugin-validator -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
+npx -y @grafana/plugin-validator@latest -sourceCodeUri [options] [path/to/plugin_archive.zip]
 ```
 
 ### Locally
 
-First you must compile and install it
+First you must compile and install it:
 
 ```SHELL
 git clone git@github.com:grafana/plugin-validator.git
@@ -44,7 +51,7 @@ cd plugin-validator/pkg/cmd/plugincheck2
 go install
 ```
 
-Then you can run the utility
+Then you can run the utility:
 
 ```SHELL
 plugincheck2 -sourceCodeUri [source_code_location/] [plugin_archive.zip]
@@ -52,25 +59,26 @@ plugincheck2 -sourceCodeUri [source_code_location/] [plugin_archive.zip]
 
 ## Options
 
+Additional options can be passed to the tool:
+
 ```
 ❯ plugincheck2 -help
 Usage plugincheck2:
   -config string (optional)
         Path to configuration file
   -sourceCodeUri string (optional)
-        URI to the source code of the plugin. If set, the source code will be downloaded and analyzed. This can be a ZIP file URL, an URL to git repository or a local file (starting with `file://`)
+        URI to the source code of the plugin. If set, the source code will be downloaded and analyzed. This can be a ZIP file URL, a URL to git repository or a local file (starting with `file://`)
   -strict (optional)
         If set, plugincheck returns non-zero exit code for warnings
 
 ```
+### Using a configuration file
 
-## Configuration
+You can pass a configuration YAML file to the validator with the `-config` option. Several configuration examples are available to use here <https://github.com/grafana/plugin-validator/tree/main/config>
 
-You can pass a configuration file to the validator with the `-config` option. Several configuraton examples are available to use here <https://github.com/grafana/plugin-validator/tree/main/config>
+#### Enabling and disabling analyzers via config
 
-### Enabling and disabling analyzers via config
-
-If you wish to disable an specific check (analyzer) you can define this in your configuration file adding an `analyzers` section and specyfing which analyzer or analyzer rules to enable and disable.
+If you wish to disable an specific check (analyzer) you can define this in your [configuration file](#using-a-configuration-file),  adding an `analyzers` section and specifying which analyzer or analyzer rules to enable and disable.
 
 E.g.: disable the `version` analyzer
 
@@ -103,22 +111,40 @@ analyzers:
 
 Severity levels could be: `error`, `warning`, `ok`
 
-Please notice that Grafanalabs uses its own configuration for plugins submissions and your own config file can't change these rules.
+> Note: Grafana Labs enforces its own configuration for plugins submissions and your own config file can't change these rules. 
+
+
+### Source code 
+You can specify the location of the plugin source code to the validator with the `-sourceCodeUri` option. Doing so allows for additional [analyzers](#analyzers) to be run and for a more complete scan.
+
+### Supported remote Git services
+
+The following **public** git services are supported
+
+- GitHub
+- GitLab
+- Bitbucket
+
+Private repositories are not currently supported.
+
+Make sure to include the ref (branch or tag) of the corresponding source code.
+
+e.g.: You are validating version `v2.1.2` and your project is in github. Make sure you create a corresponding tag or branch and use the url `https://github.com/grafana/clock-panel/tree/v2.1.2`
 
 ## Debug mode
 
 You can run the validator in debug mode to get more information about the running checks and possible errors.
 
-With Docker:
+Docker:
 
 ```SHELL
 docker run --pull=always -e DEBUG=1 grafana/plugin-validator-cli -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
 ```
 
-With NPX:
+NPX:
 
 ```SHELL
-DEBUG=1 npx -y @grafana/plugin-validator -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
+DEBUG=1 npx -y @grafana/plugin-validator@latest -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
 ```
 
 Locally:
@@ -126,24 +152,6 @@ Locally:
 ```SHELL
 DEBUG=1 plugincheck2 -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
 ```
-
-## Sourcecode and Git repositories
-
-You may pass the sourceCodeUri to the validator in order to perform source code checks (`-sourceCodeUri` option).
-
-### Using git URLs
-
-The following git services are supported
-
-- GitHub
-- GitLab
-- Bitbucket
-
-Make sure to include the ref (branch or tag) of the corresponding source code.
-
-e.g.: You are validating version `v2.1.2` and your project is in github. Make sure you create a corresponding tag or branch and use the url `https://github.com/grafana/clock-panel/tree/v2.1.2`
-
-> Do you use a different service and would like us to support it? Open a [feature request](https://github.com/grafana/clock-panel/issues)
 
 ## Security tools
 
@@ -159,144 +167,68 @@ If you run the validator locally or via NPX you can benefit from installing thes
 
 ## Analyzers
 
-The plugincheck tool runs a series of analyzers to ensure submitted plugins are following best practices, and speed up the process of approving a plugin for publishing.
+The tool runs a series of analyzers to ensure submitted plugins are following best practices, and speed up the process of approving a plugin for publishing, detailed in the table below. The Analyzer column includes the name required for altering the behavior of a given check in a [configuration file](#using-a-configuration-file). The Dependencies column specifies whether the analyzer requires the source code for the plugin to be provided with `sourceCodeUri` or for any additional [security scanning tools](#security-tools) to be present.
 
-Currently there are 20 different types of checks being performed, and are described below.
+| Analyzer | Description | Dependencies |
+| ------------- | ------------- | ------------- |
+| Archive Structure / `archive` | Ensures the contents of the zip file have the expected layout. | None |
+| Archive Name / `archivename` | The name of the archive should be correctly formatted. | None |
+| Binary Permissions / `binarypermissions` | For datasources and apps with binaries, this ensures the plugin can run when extracted on a system. | None |
+| Broken Links / `brokenlinks` | Detects if any url does not resolve to a valid location. | None |
+| Code Rules / `coderules` | Checks for forbidden access to environment variables, file system or use of `syscall` module. | [semgrep](https://github.com/returntocorp/semgrep), `sourceCodeUri` |
+| Go Manifest / `gomanifest` | Validates the build manifest. | `sourceCodeUri` |
+| Go Security Checker / `gosec` | Inspects source code for security problems by scanning the Go AST. | [[gosec](https://github.com/securego/gosec)], `sourceCodeUri` |
+| JS Source Map / `jssourcemap` | Checks for required module.js.map file(s) in archive. | `sourceCodeUri` |
+| Logos / `logos` | Detects whether the plugin includes small and large logos to display in the marketplace. | none |
+| HTML in Readme / `htmlreadme` | Detects if there are any html tags used in the README.md, as they will not render in the marketplace. | None |
+| Developer Jargon / `jargon` | Generally discourage use of code jargon in the documentation.  | None |
+| Legacy Platform / `legacyplatform`| Detects use of Angular which is deprecated. | None |
+| License Type / `license` | Ensures the license type specified is allowed [AGPL-3.0 \| Apache-2.0 \| MIT]. | None |
+| Manifest (Signing) / `manifest` | When a plugin is signed, the zip file will contain a signed MANIFEST.txt file. | None |
+| Metadata Paths / `metadapaths` | Ensures all paths are valid and images referenced exist.  | None |
+| Metadata Validity / `metadatavalid` | Ensures metadata is valid and matches plugin schema.  | None |
+| module.js (exists) / `modulejs` | All plugins require a module.js to be loaded. | None |
+| Organization (exists) / `org` | Verifies the org specified in the plugin id exists. | None |
+| Plugin Name formatting / `pluginname` | Validates the plugin id used conforms to our naming convention.  | None |
+| Published / `published` | Detects whether any version of this plugin exists on the marketplace currently | None |
+| Readme (exists) / `readme` | Ensures a README.md file exists within the zip file. | None |
+| Restrictive Dependency / `restrictivedep` | Specifies a valid range of Grafana versions that work with this version of the plugin. | None |
+| Screenshots / `screenshots` | Screenshots are specified in plugin.json that will be used in the marketplace. | None |
+| Signature / `signature` | Ensures the plugin has a valid signature. | None |
+| !Source Code / `sourcecode` | A comparison is made between the zip file and the source code to ensure what is released matches the repo associated with it. | `sourceCodeUri` |
+| Unique README.md / `templatereadme` | Ensures the plugin does not re-use the template from the create-plugin tool. | None |
+| No Tracking Scripts / `trackingscripts` | Detects if there are any known tracking scripts, which are not allowed. | None|
+| Type Suffix (panel/app/datasource) / `typesuffix` | Ensures the plugin has a valid type specified. | None |
+| Version / `version` | Ensures the version submitted is newer than the currently published plugin. If this is a new/unpublished plugin, this is skipped. | None |
+| Vulnerability Scanner / `osv-scanner` | Detects critical vulnerabilities in go modules and yarn lock files. | [osv-scanner](https://github.com/google/osv-scanner), `sourceCodeUri` |
+| Unsafe SVG / `unsafesvg` | Checks if any svg files are safe based on a whitelist of elements and attributes | none |
 
-### Archive Structure
+## Output
+By default, the tool will output results in plain text as shown below.
 
-Ensures the contents of the zip file have the expected layout.
-
-### Archive Name
-
-The name of the archive should be correctly formatted.
-
-### Binary Permissions
-
-For datasources and apps with binaries, this ensures the plugin can run when extracted on a system.
-
-### Broken Links
-
-Detects if any url does not resolve to a valid location.
-
-### HTML in Readme
-
-Detects if there are any html tags used in the README.md, as they will not render in the marketplace.
-
-### Developer Jargon
-
-Generally discourage use of code jargon in the documentation.
-
-### Legacy Platform
-
-### License Type
-
-Ensures the license type specified is allowed.
-
-### Manifest (Signing)
-
-When a plugin is signed, the zip file will contain a signed MANIFEST.txt file.
-
-### Metadata Paths and Validity
-
-Ensures all paths are valid and images referenced exist.
-
-### module.js (exists)
-
-All plugins require a module.js to be loaded.
-
-### Organization exists
-
-Verifies the org specified in the plugin id exists.
-
-### Plugin Name formatting
-
-Validates the plugin id used conforms to our naming convention.
-
-### Readme (exists)
-
-Ensures a README.md file exists within the zip file.
-
-### Restrictive Dependency
-
-Specifies a valid range of Grafana that works with this version of the plugin.
-
-### Screenshots
-
-Screenshots are specified in plugin.json that will be used in the marketplace.
-
-### Signature
-
-Ensures the plugin has a valid signature.
-
-### Source Code (NEW!)
-
-The source code URI matches the released code. A comparison is made between the zip file and the source code to ensure what is released matches the repo associated with it.
-
-### Unique README.md
-
-Ensures the plugin does not re-use the template from the create-plugin tool.
-
-### No Tracking Scripts
-
-Detects if there are any known tracking scripts, which are not allowed.
-
-### Type Suffix (panel/app/datasource)
-
-Ensures the plugin has a valid type specified.
-
-### Version
-
-Ensures the version submitted is newer than the currently published plugin. If this is a new/unpublished plugin, this is skipped.
-
-### Vulnerability Scanner
-
-This analyzer leverages the OSV Scanner (<https://github.com/google/osv-scanner>) to detect critical vulnerabilities in go modules and yarn lock files.
-
-Any critical vulnerability will cause the validation to fail and prevent a plugin from being published.
-
-Source code must be provided for this analyzer to execute, and osv-scanner needs to be in your PATH for it to run.
-
-#### Running this Analyzer
-
-Default Usage:
-
-```SHELL
-plugincheck2 -config config/default.yaml -sourceCodeUri https://github.com/briangann/grafana-gauge-panel/archive/refs/tags/v0.0.9.zip https://github.com/briangann/grafana-gauge-panel/releases/download/v0.0.9/briangann-gauge-panel-0.0.9.zip
-```
-
-Example default output:
+Default:
 
 ```TEXT
 warning: README.md: possible broken link: https://www.d3js.org (404 Not Found)
-detail: README.md might contain broken links. Check that all links are valid and publicly accesible.
+detail: README.md might contain broken links. Check that all links are valid and publicly accessible.
 warning: README.md contains developer jargon: (yarn)
 detail: Move any developer and contributor documentation to a separate file and link to it from the README.md. For example, CONTRIBUTING.md, DEVELOPMENT.md, etc.
 error: osv-scanner detected a critical severity issue
 detail: SEVERITY: CRITICAL in package immer, vulnerable to CVE-2021-23436
 error: osv-scanner detected a critical severity issue
 detail: SEVERITY: CRITICAL in package json-schema, vulnerable to CVE-2021-3918
-error: osv-scanner detected a critical severity issue
-detail: SEVERITY: CRITICAL in package loader-utils, vulnerable to CVE-2022-37601
-error: osv-scanner detected a critical severity issue
-detail: SEVERITY: CRITICAL in package minimist, vulnerable to CVE-2021-44906
-error: osv-scanner detected a critical severity issue
-detail: SEVERITY: CRITICAL in package shell-quote, vulnerable to CVE-2021-42740
-error: osv-scanner detected a critical severity issue
-detail: SEVERITY: CRITICAL in package simple-git, vulnerable to CVE-2022-25860
-error: osv-scanner detected critical severity issues
-detail: osv-scanner detected 6 unique critical severity issues for lockfile: /var/folders/84/yw3k27_j0d79r_myzgjgx1980000gn/T/validator1049475772/yarn.lock
 error: Plugin version 0.0.9 is invalid.
 detail: The submitted plugin version 0.0.9 is not greater than the latest published version 0.0.9 on grafana.com.
 ```
 
-Terse JSON Output:
+This can be changed to JSON by passing a configuration file which includes:
 
-```SHELL
-plugincheck2 -config config/terse-json.yaml -sourceCodeUri https://github.com/briangann/grafana-gauge-panel/archive/refs/tags/v0.0.9.zip https://github.com/briangann/grafana-gauge-panel/releases/download/v0.0.9/briangann-gauge-panel-0.0.9.zip
+```yaml
+global:
+  jsonOutput: true
 ```
 
-JSON:
+Resulting in output similar to:
 
 ```JSON
 {
@@ -307,7 +239,7 @@ JSON:
       {
         "Severity": "warning",
         "Title": "README.md: possible broken link: https://www.d3js.org (404 Not Found)",
-        "Detail": "README.md might contain broken links. Check that all links are valid and publicly accesible.",
+        "Detail": "README.md might contain broken links. Check that all links are valid and publicly accessible.",
         "Name": "broken-link"
       }
     ],
@@ -332,36 +264,6 @@ JSON:
         "Detail": "SEVERITY: CRITICAL in package json-schema, vulnerable to CVE-2021-3918",
         "Name": "osvscanner-critical-severity-vulnerabilities-detected"
       },
-      {
-        "Severity": "error",
-        "Title": "osv-scanner detected a critical severity issue",
-        "Detail": "SEVERITY: CRITICAL in package loader-utils, vulnerable to CVE-2022-37601",
-        "Name": "osvscanner-critical-severity-vulnerabilities-detected"
-      },
-      {
-        "Severity": "error",
-        "Title": "osv-scanner detected a critical severity issue",
-        "Detail": "SEVERITY: CRITICAL in package minimist, vulnerable to CVE-2021-44906",
-        "Name": "osvscanner-critical-severity-vulnerabilities-detected"
-      },
-      {
-        "Severity": "error",
-        "Title": "osv-scanner detected a critical severity issue",
-        "Detail": "SEVERITY: CRITICAL in package shell-quote, vulnerable to CVE-2021-42740",
-        "Name": "osvscanner-critical-severity-vulnerabilities-detected"
-      },
-      {
-        "Severity": "error",
-        "Title": "osv-scanner detected a critical severity issue",
-        "Detail": "SEVERITY: CRITICAL in package simple-git, vulnerable to CVE-2022-25860",
-        "Name": "osvscanner-critical-severity-vulnerabilities-detected"
-      },
-      {
-        "Severity": "error",
-        "Title": "osv-scanner detected critical severity issues",
-        "Detail": "osv-scanner detected 6 unique critical severity issues for lockfile: /var/folders/84/yw3k27_j0d79r_myzgjgx1980000gn/T/validator1150112313/yarn.lock",
-        "Name": "osvscanner-critical-severity-vulnerabilities-detected"
-      }
     ],
     "version": [
       {
@@ -375,11 +277,22 @@ JSON:
 }
 ```
 
-Verbose
+### Severity
 
-```SHELL
-plugincheck2 -config config/verbose-json.yaml -sourceCodeUri https://github.com/briangann/grafana-gauge-panel/archive/refs/tags/v0.0.9.zip https://github.com/briangann/grafana-gauge-panel/releases/download/v0.0.9/briangann-gauge-panel-0.0.9.zip
+By default the tool will show any warning or error level results from the analyzers. To see all results including successes, you can pass a configuration file which includes:
+
+```yaml
+global:
+  reportAll: true
 ```
+
+## Getting Help
+
+- :open_book: Check out our plugin [documentation](https://grafana.com/docs/grafana/latest/developers/plugins/).
+- See our other [Plugin Tools](https://grafana.github.io/plugin-tools/) to create and update plugins.  
+- :handshake: Join the [community forum](https://community.grafana.com/tag/plugins).  
+- :speech_balloon: Chat to us in the Grafana Slack [#plugins channel](https://grafana.slack.com/archives/C3HJV5PNE).  
+- :memo: [File an issue](https://github.com/grafana/plugin-validator/issues) for any bugs or feature requests.  
 
 ## License
 


### PR DESCRIPTION
This PR makes a number of changes to the readme:
- General rewordings and expanding on details
- Adds CI and Go Report Shields
- Removes _arguably_ unnecessary content in the npx/local examples and strips some content from example output
- Replaces the Analyzers section with a new table format to save space and specifies the function names for each analyzer
- Removes reference for feature requests on additional git providers
- Updates npx command to add `@latest` to ensure users always run latest version and dont hit potential issues due to cached versions
- Adds new getting help section which has a generic "raise feature request" call to action
- Adds new Analyzers to the table and attempts to explain them. Some (listed below) _seemingly_ don't appear even in tool output even when `reportAll: true` is configured, so _may_ need removing? Perhaps they can't be configured individually through a config file?
  - gomanifest
  - jssourcemap
  - pluginname
  - logos
  - sourcecode
  - published (guessing just used in version?)
  - unsafesvg
- It advises that private repositories are not supported (assumption)


Potential follow ups and questions **not** addressed through this PR:
- Are local git repositories (not just zips) supported for `-sourceCodeUri`?
- Are non-git locations supported for remote zip files i.e.  FTP servers?
- Can we share or reference the Grafana Labs configuration required for publishing to the catalog (is this the default behaviour)?
- Can the naming convention be shared?
- Add (at least) code of conduct and contributing guidelines 
- The local steps will only work if the user has set up their $PATH appropriately, maybe worth advising, might be too much detail?