### PR TITLE
Fix sourcemap validation

### DIFF
--- a/pkg/sourcemap/sourcemap.go
+++ b/pkg/sourcemap/sourcemap.go
@@ -2,6 +2,7 @@ package sourcemap
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,6 +45,18 @@ func ParseSourceMapFromBytes(data []byte) (*sourceMap, error) {
 		return nil, err
 	}
 
+	if len(rawSourceMap.Sources) == 0 {
+		return nil, errors.New("generated source code map requires the original source file paths to be present in the sources property")
+	}
+
+	if len(rawSourceMap.SourcesContent) == 0 {
+		return nil, errors.New("generated source code map requires the original source code to be present in the sourcesContent property")
+	}
+
+	if len(rawSourceMap.Sources) != len(rawSourceMap.SourcesContent) {
+		return nil, errors.New("generated source code map requires the number of original source file paths (sources) to match with the number of original source code (sourcesContent)")
+	}
+
 	parseSourceMap := sourceMap{
 		Version: rawSourceMap.Version,
 		Sources: map[string]string{},
@@ -53,6 +66,7 @@ func ParseSourceMapFromBytes(data []byte) (*sourceMap, error) {
 		if isIgnoredFile(fileName) {
 			continue
 		}
+
 		parseSourceMap.Sources[fileName] = rawSourceMap.SourcesContent[i]
 	}
 	return &parseSourceMap, nil

--- a/pkg/sourcemap/sourcemap_test.go
+++ b/pkg/sourcemap/sourcemap_test.go
@@ -1,0 +1,103 @@
+package sourcemap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSourceMapFromBytes(t *testing.T) {
+	tcs := []struct {
+		desc              string
+		json              string
+		expectedError     string
+		expectedSourceMap *sourceMap
+	}{
+		{
+			desc: "empty sources",
+			json: `{
+				"version": 3,
+				"sourcesContent": [
+					"a",
+					"b",
+					"c"
+				]
+			}`,
+			expectedError: "generated source code map requires the original source file paths to be present in the sources property",
+		},
+		{
+			desc: "empty sourcesContent",
+			json: `{
+				"version": 3,
+				"sources": [
+					"a",
+					"b",
+					"c"
+				]
+			}`,
+			expectedError: "generated source code map requires the original source code to be present in the sourcesContent property",
+		},
+		{
+			desc: "source and sourcesContent mismatch",
+			json: `{
+				"version": 3,
+				"sources": [
+					"a",
+					"b",
+					"c"
+				],
+				"sourcesContent": [
+					"d",
+					"e"
+				]
+			}`,
+			expectedError: "generated source code map requires the number of original source file paths (sources) to match with the number of original source code (sourcesContent)",
+		},
+		{
+			desc: "valid",
+			json: `{
+				"version": 3,
+				"sources": [
+					"components/test.tsx",
+					"external abc",
+					"webpack/abc",
+					"../node_modules/abc",
+					"./node_modules/abc",
+					"components/test2.tsx"
+				],
+				"sourcesContent": [
+					"abc",
+					"",
+					"",
+					"",
+					"",
+					"def"
+				]
+			}`,
+			expectedSourceMap: &sourceMap{
+				Version: 3,
+				Sources: map[string]string{
+					"components/test.tsx":  "abc",
+					"components/test2.tsx": "def",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			sourceMap, err := ParseSourceMapFromBytes([]byte(tc.json))
+			if tc.expectedError != "" {
+				require.Equal(t, tc.expectedError, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.expectedSourceMap != nil {
+				require.Equal(t, tc.expectedSourceMap, sourceMap)
+			} else {
+				require.Nil(t, tc.expectedSourceMap)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixing panics by validating sourcemaps are valid. Panic example:
```
❯ ./bin/linux_amd64/plugincheck2 -config ./config/terse-json.yaml -sourceCodeUri https://github.com/TencentCloud/tencentcloud-monitor-grafana-app ~/Downloads/tencentcloud-monitor-app-2.8.2.zip           
Cloning into '/tmp/validator3743180710'...
remote: Enumerating objects: 436, done.
remote: Counting objects: 100% (436/436), done.
remote: Compressing objects: 100% (356/356), done.
remote: Total 436 (delta 149), reused 274 (delta 69), pack-reused 0
Receiving objects: 100% (436/436), 29.30 MiB | 3.88 MiB/s, done.
Resolving deltas: 100% (149/149), done.
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/grafana/plugin-validator/pkg/sourcemap.ParseSourceMapFromBytes({0xc005680000, 0x83d4f, 0x83d50})
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/sourcemap/sourcemap.go:56 +0x22d
github.com/grafana/plugin-validator/pkg/sourcemap.ParseSourceMapFromPath({0xc0053f1100?, 0x1c?})
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/sourcemap/sourcemap.go:37 +0x3c
github.com/grafana/plugin-validator/pkg/difftool.CompareSourceMapToSourceCode({0xc0053f1100, 0x35}, {0xc0053e4fe0, 0x1c})
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/difftool/difftool.go:42 +0xc5
github.com/grafana/plugin-validator/pkg/analysis/passes/jssourcemap.run(0xc0032c0900)
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/analysis/passes/jssourcemap/jssourcemap.go:73 +0x2a6
github.com/grafana/plugin-validator/pkg/runner.Check.func2(0x14cd180)
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/runner/runner.go:88 +0x251
github.com/grafana/plugin-validator/pkg/runner.Check({0x14d93a0, 0x20, 0x20}, {0xc0022c0040, 0xe}, {0xc00185ff40, 0x19}, {{0x1, {0xc0022c1478, 0x7}, ...}, ...})
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/runner/runner.go:98 +0x2f0
main.main()
        /home/marcus/go/src/github.com/grafana/plugin-validator/pkg/cmd/plugincheck2/main.go:77 +0x7bb
```

Adding validation to make sure `sources` and `sourcesContent` are set and their lengths doesn't mismatch.

With the changes I get the following output:
```json
{                                                                                                                              
  "id": "tencentcloud-monitor-app",                                                                                            
  "version": "2.8.2",                                                                                                          
  "plugin-validator": {
    "go-manifest": [
      {       
        "Severity": "warning",
        "Title": "Could not find or parse Go manifest file",                   
        "Detail": "Your source code contains Go files but there's no Go build manifest. Make sure you are using the latest version of the Go plugin SDK",
        "Name": "no-go-manifest"                                                                                               
      }                                                        
    ],                                                         
    "jsMap": [
      {
        "Severity": "error",
        "Title": "the sourcemap file /tmp/576158446/tencentcloud-monitor-app/module.js.map could not be validated",                                            
        "Detail": "You must include generated source maps for your plugin in your archive file. If you have nested plugins, you must include the source maps fo
r each plugin",                                                
        "Name": "js-map-invalid"                                                                                               
      } 
    ],                                                         
    "legacyplatform": [
      {
        "Severity": "warning",         
        "Title": "module.js: uses legacy plugin platform",                     
        "Detail": "The plugin uses the legacy plugin platform (AngularJS). Please migrate the plugin to use the new plugins platform.",
        "Name": "legacy-platform"                                              
      }                                
    ]                                  
  }                                    
}         
```