### PR TITLE
fix: return ok when screenshots don't exist

### DIFF
--- a/pkg/analysis/passes/screenshots/screenshots.go
+++ b/pkg/analysis/passes/screenshots/screenshots.go
@@ -31,7 +31,7 @@ func checkScreenshotsExist(pass *analysis.Pass) (interface{}, error) {
 	if len(data.Info.Screenshots) == 0 {
 		explanation := "Screenshots are displayed in the plugin's catalog. Please add at least one screenshot to your plugin.json."
 		pass.ReportResult(pass.AnalyzerName, screenshots, "plugin.json: should include screenshots for marketplace", explanation)
-		return nil, nil
+		return data.Info.Screenshots, nil
 	} else {
 		reportCount := 0
 		for _, screenshot := range data.Info.Screenshots {

--- a/pkg/analysis/passes/screenshots/screenshots_test.go
+++ b/pkg/analysis/passes/screenshots/screenshots_test.go
@@ -52,7 +52,8 @@ func TestNoScreenshots(t *testing.T) {
 		Report: interceptor.ReportInterceptor(),
 	}
 
-	_, err := Analyzer.Run(pass)
+	res, err := Analyzer.Run(pass)
+	require.Len(t, res, 0)
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "plugin.json: should include screenshots for marketplace")


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-validator/issues/101

As per https://github.com/grafana/plugin-validator/issues/101#issuecomment-1473559194, return an empty array when there are no screenshots, that way `metadatapaths` will still run.