### PR TITLE
Avoid gomanifest check for non-backend plugins

### DIFF
--- a/pkg/analysis/passes/gomanifest/gomanifest_test.go
+++ b/pkg/analysis/passes/gomanifest/gomanifest_test.go
@@ -6,9 +6,15 @@ import (
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
 	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	pluginJSONWithBackend    = []byte(`{"backend": true}`)
+	pluginJSONWithoutBackend = []byte(`{}`)
 )
 
 func TestSrcWithGoFilesNoManifest(t *testing.T) {
@@ -18,6 +24,7 @@ func TestSrcWithGoFilesNoManifest(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "no-manifest", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "no-manifest", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -35,6 +42,7 @@ func TestSrcWithoutGoFiles(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "no-go-files", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "no-go-files", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -51,6 +59,7 @@ func TestCorrectManifest(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "correct-manifest", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "correct-manifest", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -67,6 +76,7 @@ func TestIncorrectManifest(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "incorrect-manifest", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "incorrect-manifest", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -84,6 +94,7 @@ func TestMissingFileInManifest(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "missing-file-in-manifest", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "missing-file-in-manifest", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -101,6 +112,7 @@ func TestMissingFileInSourceCode(t *testing.T) {
 		ResultOf: map[*analysis.Analyzer]interface{}{
 			archive.Analyzer:    filepath.Join("testdata", "missing-file-in-source-code", "dist"),
 			sourcecode.Analyzer: filepath.Join("testdata", "missing-file-in-source-code", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
@@ -109,4 +121,21 @@ func TestMissingFileInSourceCode(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "The Go build manifest does not match the source code")
+}
+
+func TestNoBackend(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer:    filepath.Join("testdata", "no-manifest", "dist"),
+			sourcecode.Analyzer: filepath.Join("testdata", "no-manifest", "src"),
+			metadata.Analyzer:   pluginJSONWithoutBackend,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
 }

--- a/pkg/analysis/passes/metadata/types.go
+++ b/pkg/analysis/passes/metadata/types.go
@@ -6,6 +6,7 @@ type Metadata struct {
 	Type       string       `json:"type"`
 	Info       MetadataInfo `json:"info"`
 	Executable string       `json:"executable"`
+	Backend    bool         `json:"backend"`
 }
 
 type MetadataInfo struct {


### PR DESCRIPTION
Fix an issue that the gomanifest check fails when it finds some go code in the repo but the plugin is not a backend plugin. 

https://grafana.zendesk.com/agent/tickets/84488