### PR TITLE
Ignore SVG files for sourcemap diff

### DIFF
--- a/pkg/sourcemap/sourcemap.go
+++ b/pkg/sourcemap/sourcemap.go
@@ -110,8 +110,11 @@ func isIgnoredFile(sourceName string) bool {
 	if strings.Contains(sourceName, "?") {
 		sourceName = sourceName[:strings.Index(sourceName, "?")]
 	}
-	if strings.HasSuffix(sourceName, ".css") {
-		return true
+	var ignoredExtensions = []string{".css", ".scss", ".sass", ".less", ".svg"}
+	for _, ext := range ignoredExtensions {
+		if strings.HasSuffix(sourceName, ext) {
+			return true
+		}
 	}
 	// ignore external and webpack bootstrap iles
 	ignore := false


### PR DESCRIPTION
Ignores svg files to check content diff. SVG files are already verified for malicious code in another check and generally webpack will reprocess them into module imports that will keep reporting false negatives
