### PR TITLE
Ignores files that contain pnpm folder structure signature

### DIFF
--- a/pkg/sourcemap/sourcemap.go
+++ b/pkg/sourcemap/sourcemap.go
@@ -110,6 +110,9 @@ func isIgnoredFile(sourceName string) bool {
 	if strings.Contains(sourceName, "?") {
 		sourceName = sourceName[:strings.Index(sourceName, "?")]
 	}
+	if strings.Contains(sourceName, "/node_modules/.pnpm/") {
+		return true
+	}
 	var ignoredExtensions = []string{".css", ".scss", ".sass", ".less", ".svg"}
 	for _, ext := range ignoredExtensions {
 		if strings.HasSuffix(sourceName, ext) {


### PR DESCRIPTION
Adds pnpm folder structure to sourcemaps validation.

Grafana toolkit has a tendency to add node_modules files from pnpm and generates false positives in the validator
