### PR TITLE
Check latest Go version when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "~1.20"
-          cache: true
+          check-latest: true
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "~1.20"
-          cache: true
+          check-latest: true
 
       - name: Install dependencies
         run: go get .


### PR DESCRIPTION
Based on https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs v4 caching is enabled by default. Adding a check for the latest version in addition