### PR TITLE
Ignore json files for sourcemap validation

### DIFF
--- a/pkg/sourcemap/sourcemap.go
+++ b/pkg/sourcemap/sourcemap.go
@@ -113,7 +113,7 @@ func isIgnoredFile(sourceName string) bool {
 	if strings.Contains(sourceName, "/node_modules/.pnpm/") {
 		return true
 	}
-	var ignoredExtensions = []string{".css", ".scss", ".sass", ".less", ".svg"}
+	var ignoredExtensions = []string{".css", ".scss", ".sass", ".less", ".svg", ".json"}
 	for _, ext := range ignoredExtensions {
 		if strings.HasSuffix(sourceName, ext) {
 			return true


### PR DESCRIPTION
The sourcemap validation should skip json files
