### PR TITLE
Fallback to use the first available plugin.json if not found in the expected location

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -260,6 +261,12 @@ func (Run) V2Local(ctx context.Context, path string, sourceCodePath string) erro
 
 func (Run) SourceDiffLocal(ctx context.Context, archive string, source string) error {
 	buildCommand("sourcemapdiff", runtime.GOOS+"_"+runtime.GOARCH)
+
+	// if source doesn't start with http or file:// add file://
+	if !strings.HasPrefix(source, "http://") && !strings.HasPrefix(source, "file://") {
+		source = "file://" + source
+	}
+
 	command := []string{
 		"./bin/" + runtime.GOOS + "_" + runtime.GOARCH + "/sourcemapdiff",
 		"-archiveUri", archive}

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -86,8 +86,7 @@ func main() {
 	if cfg.Global.JSONOutput {
 		pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
 		if err != nil {
-			pluginID = "unknown"
-			pluginVersion = "unknown"
+			pluginID, pluginVersion = GetIDAndVersionFallBack(archiveDir)
 			archiveDiag := analysis.Diagnostic{
 				Name:     "zip-invalid",
 				Severity: analysis.Error,


### PR DESCRIPTION
- Fallbacks to detect the plugin id from the first plugin.json if not found in the expected location
- Correctly finds if the code provided in a zip file is inside a subdirectory.
