### PR TITLE
Add validation for a signature to not contain rootUrls

### DIFF
--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -63,7 +63,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// a non private signature can't have rootUrls
-	if manifest.SignatureType != "private" && len(manifest.RootUrls) > 0 {
+	if manifest.SignatureType != "private" && manifest.SignatureType != "private-glob" && len(manifest.RootUrls) > 0 {
 		pass.ReportResult(pass.AnalyzerName, invalidSignature, "MANIFEST.txt: plugin signature contains rootUrls", fmt.Sprintf("The plugin is signed as %s but contains rootUrls. Do not pass --rootUrls when signing this plugin as %s type", manifest.SignatureType, manifest.SignatureType))
 		return nil, nil
 	}

--- a/pkg/analysis/passes/manifest/manifest_test.go
+++ b/pkg/analysis/passes/manifest/manifest_test.go
@@ -134,3 +134,20 @@ func TestInvalidChecksum(t *testing.T) {
 	require.Equal(t, interceptor.Diagnostics[0].Title, "invalid file checksum")
 	require.Equal(t, interceptor.Diagnostics[0].Detail, "checksum for file module.js is invalid")
 }
+
+func TestCommunityWithRootUrls(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("testdata", "with-root-urls"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, interceptor.Diagnostics[0].Title, "MANIFEST.txt: plugin signature contains rootUrls")
+	require.Equal(t, interceptor.Diagnostics[0].Detail, "The plugin is signed as community but contains rootUrls. Do not pass --rootUrls when signing this plugin as community type")
+}

--- a/pkg/analysis/passes/manifest/testdata/with-root-urls/MANIFEST.txt
+++ b/pkg/analysis/passes/manifest/testdata/with-root-urls/MANIFEST.txt
@@ -1,0 +1,40 @@
+
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+{
+  "manifestVersion": "2.0.0",
+  "signatureType": "community",
+  "signedByOrg": "grafana",
+  "signedByOrgName": "Grafana Labs",
+  "plugin": "grafana-clock-panel",
+  "version": "2.1.2",
+  "time": 1672825174657,
+  "keyId": "7e4d0c6a708866e7",
+  "rootUrls": ["https://localhost:3000"],
+  "files": {
+    "CHANGELOG.md": "d9183b9e669b1ee94da93626a0f99d874b07c71adbe5b8a8213815f9e7c76f7f",
+    "LICENSE": "b46400c1ab5630edeb4e43b240a027d203375ebe5a9efb7de88c604c5c5cace0",
+    "README.md": "265b2b3c4f46881ff656089aa2561f98ae672c6045f7db73e667853d2ff11960",
+    "img/clock.svg": "d27cbdb85432fe1ad96eeec6758c2c4a0b189b306ba2040519aec09938889fbc",
+    "img/countdown1.png": "ce51c235273667dde4a8fedc36ea70c6bfa7670b247514a2ae1654bd872548aa",
+    "img/screenshot-clock-options.png": "55f428cc45f65e53a118db2b969353cd01e0d2f879848b1df503750ed27007cf",
+    "img/screenshot-clocks.png": "4dcf3c3d303e63239689df853b80ef79557eaf5496679400f362e68f57f60577",
+    "img/screenshot-showcase.png": "43c6520f1efa3343d839b9462a22ce962d2b041f2d5d9c743a8603caa8392a71",
+    "module.js": "f38c235449ccbf82449117334846c961dc54bce817d591bfe69b56b006b6f7c7",
+    "module.js.LICENSE.txt": "a289e86d118eb1e42b697e70dbd8f06f268116074d4bbb6f4e4e92075b57d9b6",
+    "module.js.map": "b193cc7ad3d30fa2b00548d0f4e5f707f55f67b31ec51e753e24c68af8a6b25b",
+    "plugin.json": "8b27798514900749f5e167b83dcbf04d1fcf9d8743db991eca3e66f4de676d46"
+  }
+}
+-----BEGIN PGP SIGNATURE-----
+Version: OpenPGP.js v4.10.10
+Comment: https://openpgpjs.org
+
+wrkEARMKAAYFAmO1SVYAIQkQfk0ManCIZucWIQTzOyW2kQdOhGNlcPN+TQxq
+cIhm51CeAgkBUX8Nc3GaBIEBeE72fAyVFLr5kcMviuDzYvlcU3yhpNMBBEjX
+o5fLcECAZtrdf2ddBWtsaAbuBvO3jCFnZ9Z6YIcCCQEh1WC2jJSS2lvi8pCW
+ljmXRedB6QPeChQrXA0PoFDonSas+HlW3b+HJJ9tOz80leKd/8LdQEMAFEsZ
+hGRa6WiXgw==
+=7uUw
+-----END PGP SIGNATURE-----

--- a/pkg/analysis/passes/manifest/types.go
+++ b/pkg/analysis/passes/manifest/types.go
@@ -1,5 +1,7 @@
 package manifest
 
 type ManifestFile struct {
-	Files map[string]string `json:"files"`
+	Files         map[string]string `json:"files"`
+	RootUrls      []string          `json:"rootUrls"`
+	SignatureType string            `json:"signatureType"`
 }


### PR DESCRIPTION
Validate that signatures don't contain a rootUrl when they are not signed as private plugins

Closes https://github.com/grafana/plugin-validator/issues/134
