### PR TITLE
Legacy platform: Removed getLegacyAngularInjector Angular pattern

### DIFF
--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -53,7 +53,6 @@ var legacyDetectors = []detector{
 	&containsBytesDetector{pattern: []byte("angular.isNumber(")},
 	&containsBytesDetector{pattern: []byte("editor.html")},
 	&containsBytesDetector{pattern: []byte("ctrl.annotation")},
-	&containsBytesDetector{pattern: []byte("getLegacyAngularInjector")},
 	&containsBytesDetector{pattern: []byte("System.register(")},
 
 	// &regexDetector{regex: regexp.MustCompile(`['"](app/core/.*?)|(app/plugins/.*?)['"]`)},


### PR DESCRIPTION
Removed `getLegacyAngularInjector` from the list of angular patterns as it's problematic.

Grafana core PR: https://github.com/grafana/grafana/pull/74862