### PR TITLE
Run validators with dependencies returning `nil`

### DIFF
--- a/pkg/analysis/passes/archive/archive.go
+++ b/pkg/analysis/passes/archive/archive.go
@@ -31,6 +31,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pass.ReportResult(pass.AnalyzerName, emptyArchive, "Archive is empty", "")
 		return nil, nil
 	}
+
 	if emptyArchive.ReportAll {
 		emptyArchive.Severity = analysis.OK
 		pass.ReportResult(pass.AnalyzerName, emptyArchive, "Archive is not empty", "")

--- a/pkg/analysis/passes/archivename/archivename.go
+++ b/pkg/analysis/passes/archivename/archivename.go
@@ -22,8 +22,15 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/binarypermissions/binarypermissions.go
+++ b/pkg/analysis/passes/binarypermissions/binarypermissions.go
@@ -35,8 +35,15 @@ var binarySuffixes = []string{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/brokenlinks/brokenlinks.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks.go
@@ -33,8 +33,15 @@ type contextURL struct {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
-	readme := pass.ResultOf[readme.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+
+	readme, ok := pass.ResultOf[readme.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var urls []contextURL
 

--- a/pkg/analysis/passes/gomanifest/gomanifest.go
+++ b/pkg/analysis/passes/gomanifest/gomanifest.go
@@ -35,7 +35,7 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
 	if !ok {
-		return nil, errors.New("metadata not found")
+		return nil, nil
 	}
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/jargon/jargon.go
+++ b/pkg/analysis/passes/jargon/jargon.go
@@ -26,11 +26,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		"nodejs",
 	}
 
-	b := pass.ResultOf[readme.Analyzer].([]byte)
+	readmeContent, ok := pass.ResultOf[readme.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var found []string
 	for _, word := range jargon {
-		if bytes.Contains(b, []byte(word)) {
+		if bytes.Contains(readmeContent, []byte(word)) {
 			found = append(found, word)
 		}
 	}

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -62,10 +62,14 @@ var legacyDetectors = []detector{
 
 func run(pass *analysis.Pass) (interface{}, error) {
 
-	_, ok := pass.ResultOf[published.Analyzer].(*published.PluginStatus)
+	status, ok := pass.ResultOf[published.Analyzer].(*published.PluginStatus)
+
+	if !ok {
+		return nil, nil
+	}
 
 	// we don't fail published plugins for using angular
-	if ok {
+	if status.Status != "unknown" {
 		legacyPlatform.Severity = analysis.Warning
 	}
 

--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -44,6 +44,9 @@ func TestLegacyPlatformUsesLegacy(t *testing.T) {
 			RootDir: filepath.Join("./"),
 			ResultOf: map[*analysis.Analyzer]interface{}{
 				modulejs.Analyzer: moduleJsMap,
+				published.Analyzer: &published.PluginStatus{
+					Status: "unknown",
+				},
 			},
 			Report: interceptor.ReportInterceptor(),
 		}

--- a/pkg/analysis/passes/license/license.go
+++ b/pkg/analysis/passes/license/license.go
@@ -37,7 +37,10 @@ var validLicensesRegex = []*regexp.Regexp{
 const minRequiredConfidenceLevel float32 = 0.9
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
 
 	// validate that a LICENSE file is provided (go standard lib method)
 	licenseFilePath := filepath.Join(archiveDir, "LICENSE")

--- a/pkg/analysis/passes/logos/logos.go
+++ b/pkg/analysis/passes/logos/logos.go
@@ -20,7 +20,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -34,7 +34,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
 
 	b, err := os.ReadFile(filepath.Join(archiveDir, "MANIFEST.txt"))
 	if err != nil {

--- a/pkg/analysis/passes/metadata/metadata.go
+++ b/pkg/analysis/passes/metadata/metadata.go
@@ -20,7 +20,11 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+
+	if !ok {
+		return nil, nil
+	}
 
 	b, err := os.ReadFile(filepath.Join(archiveDir, "plugin.json"))
 	if err != nil {

--- a/pkg/analysis/passes/metadatapaths/metadatapaths.go
+++ b/pkg/analysis/passes/metadatapaths/metadatapaths.go
@@ -50,7 +50,10 @@ func checkMetadataPaths(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// Logos
-	logos := pass.ResultOf[logos.Analyzer].(metadata.MetadataLogos)
+	logos, ok := pass.ResultOf[logos.Analyzer].(metadata.MetadataLogos)
+	if !ok {
+		return nil, nil
+	}
 	paths = append(paths, struct {
 		kind string
 		path string

--- a/pkg/analysis/passes/metadatavalid/metadatavalid.go
+++ b/pkg/analysis/passes/metadatavalid/metadatavalid.go
@@ -15,18 +15,22 @@ import (
 )
 
 var (
-	invalidMetadata = &analysis.Rule{Name: "invalid-metadata", Severity: analysis.Warning}
+	invalidMetadata  = &analysis.Rule{Name: "invalid-metadata", Severity: analysis.Warning}
+	metadataNotFound = &analysis.Rule{Name: "metadata-not-found", Severity: analysis.Error}
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "metadatavalid",
 	Requires: []*analysis.Analyzer{metadata.Analyzer, metadataschema.Analyzer},
 	Run:      run,
-	Rules:    []*analysis.Rule{invalidMetadata},
+	Rules:    []*analysis.Rule{invalidMetadata, metadataNotFound},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	schema := pass.ResultOf[metadataschema.Analyzer].([]byte)
+	schema, ok := pass.ResultOf[metadataschema.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	schemaFile, err := os.CreateTemp("", "plugin_*.schema.json")
 	if err != nil {
@@ -45,13 +49,22 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, err
 	}
 
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
 
 	// Using the path here rather than the result of metadata.Analyzer since
 	// gojsonschema needs an actual file.
 	metadataPath, err := filepath.Abs(filepath.Join(archiveDir, "plugin.json"))
 	if err != nil {
 		return nil, err
+	}
+
+	_, err = os.Stat(metadataPath)
+	if err != nil {
+		pass.ReportResult(pass.AnalyzerName, metadataNotFound, "plugin.json not found", "plugin.json not found in the archive. Please refer to the documentation for more information. https://grafana.com/docs/grafana/latest/developers/plugins/metadata/")
+		return nil, nil
 	}
 
 	schemaLoader := gojsonschema.NewReferenceLoader("file:///" + schemaPath)

--- a/pkg/analysis/passes/metadatavalid/metadatavalid.go
+++ b/pkg/analysis/passes/metadatavalid/metadatavalid.go
@@ -62,9 +62,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	_, err = os.Stat(metadataPath)
-	if err != nil {
+	switch {
+	case os.IsNotExist(err):
 		pass.ReportResult(pass.AnalyzerName, metadataNotFound, "plugin.json not found", "plugin.json not found in the archive. Please refer to the documentation for more information. https://grafana.com/docs/grafana/latest/developers/plugins/metadata/")
 		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("%q stat: %w", metadataPath, err)
+	case err == nil:
+		break	
 	}
 
 	schemaLoader := gojsonschema.NewReferenceLoader("file:///" + schemaPath)

--- a/pkg/analysis/passes/modulejs/modulejs.go
+++ b/pkg/analysis/passes/modulejs/modulejs.go
@@ -1,7 +1,6 @@
 package modulejs
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -24,7 +23,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
 	if !ok || archiveDir == "" {
 		// this should never happen
-		return nil, fmt.Errorf("archive dir not found")
+		return nil, nil
 	}
 
 	//find all module.js files with doublestar

--- a/pkg/analysis/passes/org/org.go
+++ b/pkg/analysis/passes/org/org.go
@@ -22,7 +22,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/pluginname/pluginname.go
+++ b/pkg/analysis/passes/pluginname/pluginname.go
@@ -25,10 +25,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	_, ok = pass.ResultOf[published.Analyzer].(*published.PluginStatus)
+	publishStatus, ok := pass.ResultOf[published.Analyzer].(*published.PluginStatus)
 
 	// we don't check published plugins for naming conventions
-	if ok {
+	if ok && publishStatus.Status != "unknown" {
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/published/published.go
+++ b/pkg/analysis/passes/published/published.go
@@ -41,7 +41,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	pluginStatus, err := getPluginDataFromGrafanaCom(context, data.ID)
 	if err != nil {
 		// in case of any error getting the online status, skip this check
-		return nil, nil
+		return &PluginStatus{
+			Status: "unknown",
+		}, nil
 	}
 
 	return pluginStatus, nil

--- a/pkg/analysis/passes/published/published_test.go
+++ b/pkg/analysis/passes/published/published_test.go
@@ -97,7 +97,9 @@ func TestUnpublishedPlugin(t *testing.T) {
 
 	require.Len(t, httpmock.GetCallCountInfo(), 1)
 	require.Len(t, interceptor.Diagnostics, 0)
-	require.Nil(t, analyzerResult)
+	require.Equal(t, analyzerResult, &PluginStatus{
+		Status: "unknown",
+	})
 }
 
 func TestPublishedPlugin(t *testing.T) {

--- a/pkg/analysis/passes/readme/readme.go
+++ b/pkg/analysis/passes/readme/readme.go
@@ -21,7 +21,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
 
 	b, err := os.ReadFile(filepath.Join(archiveDir, "README.md"))
 	if err != nil {

--- a/pkg/analysis/passes/restrictivedep/restrictivedep.go
+++ b/pkg/analysis/passes/restrictivedep/restrictivedep.go
@@ -23,7 +23,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadata := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadata, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data struct {
 		Dependencies struct {

--- a/pkg/analysis/passes/screenshots/screenshots.go
+++ b/pkg/analysis/passes/screenshots/screenshots.go
@@ -21,7 +21,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func checkScreenshotsExist(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/signature/signature.go
+++ b/pkg/analysis/passes/signature/signature.go
@@ -35,9 +35,20 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	archiveDir := pass.ResultOf[archive.Analyzer].(string)
-	metadata := pass.ResultOf[metadata.Analyzer].([]byte)
-	manifest := pass.ResultOf[manifest.Analyzer].([]byte)
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	metadata, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+
+	manifest, ok := pass.ResultOf[manifest.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data struct {
 		ID   string `json:"id"`

--- a/pkg/analysis/passes/templatereadme/templatereadme.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme.go
@@ -19,7 +19,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	readme := pass.ResultOf[readme.Analyzer].([]byte)
+	readme, ok := pass.ResultOf[readme.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	re := regexp.MustCompile("(?i)Grafana (Panel|Data Source|Datasource|App|Data Source Backend) Plugin Template")
 

--- a/pkg/analysis/passes/typesuffix/typesuffix.go
+++ b/pkg/analysis/passes/typesuffix/typesuffix.go
@@ -21,7 +21,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
 	var data metadata.Metadata
 	if err := json.Unmarshal(metadataBody, &data); err != nil {

--- a/pkg/analysis/passes/unsafesvg/unsafesvg.go
+++ b/pkg/analysis/passes/unsafesvg/unsafesvg.go
@@ -24,7 +24,7 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
 	if !ok {
-		return nil, fmt.Errorf("failed to get archive dir")
+		return nil, nil
 	}
 
 	svgValidator := svgvalidate.NewValidator()

--- a/pkg/analysis/passes/version/version.go
+++ b/pkg/analysis/passes/version/version.go
@@ -50,7 +50,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// if the plugin is not published, skip this check
-	if pluginStatus == nil {
+	if pluginStatus.Status == "unknown" {
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/version/version_test.go
+++ b/pkg/analysis/passes/version/version_test.go
@@ -36,6 +36,10 @@ func setupTestAnalyzer(pluginSubmissionVersion string, pluginGrafanaComVersion s
 			Slug:    testPluginId,
 			Version: pluginGrafanaComVersion,
 		}
+	} else {
+		pluginStatus = &published.PluginStatus{
+			Status: "unknown",
+		}
 	}
 
 	pass := &analysis.Pass{

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -212,7 +211,6 @@ func TestDependencyReturnsNil(t *testing.T) {
 	parent := &analysis.Analyzer{
 		Name: "parent",
 		Run: func(pass *analysis.Pass) (interface{}, error) {
-			fmt.Println("parent run")
 			res["parent"] = nil
 			return nil, nil
 		},
@@ -221,7 +219,6 @@ func TestDependencyReturnsNil(t *testing.T) {
 		Name:     "firstChild",
 		Requires: []*analysis.Analyzer{parent},
 		Run: func(pass *analysis.Pass) (interface{}, error) {
-			fmt.Println("firstChild run")
 			res["firstChild"] = true
 			return true, nil
 		},


### PR DESCRIPTION
The original runner logic will skip validators that have dependencies returning nil.

This was under the idea that validator's dependencies are always required ("hard" dependencies)

Some new validators have "Soft" dependencies which means they can still run some checks even if the dependencies are nil

Additionally the code for many validators was not safe because it was optimistic about the result of the validator's dependencies and could cause panics.

This PR also fixes the code in all the validators that were optimistic about the result of the validator's dependencies.
