### PR TITLE
Clarify unsigned message for new plugins

### DIFF
--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/published"
 
 	// even though deprecated this is what grafana is using at the moment
 	// https://github.com/grafana/grafana/blob/main/pkg/plugins/manager/signature/manifest.go
@@ -28,7 +29,7 @@ var (
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "manifest",
-	Requires: []*analysis.Analyzer{archive.Analyzer},
+	Requires: []*analysis.Analyzer{archive.Analyzer, published.Analyzer},
 	Run:      run,
 	Rules:    []*analysis.Rule{unsignedPlugin, undeclaredFiles, emptyManifest, wrongManifest, invalidShaSum},
 }
@@ -36,11 +37,22 @@ var Analyzer = &analysis.Analyzer{
 func run(pass *analysis.Pass) (interface{}, error) {
 	archiveDir := pass.ResultOf[archive.Analyzer].(string)
 
+	publishStatus, ok := pass.ResultOf[published.Analyzer].(*published.PluginStatus)
+	isPublished := false
+	if ok && publishStatus.Status != "unknown" {
+		isPublished = true
+	}
+
 	b, err := os.ReadFile(filepath.Join(archiveDir, "MANIFEST.txt"))
 	if err != nil {
 		if os.IsNotExist(err) {
 
-			pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "unsigned plugin", "MANIFEST.txt file not found. Please refer to the documentation for how to sign a plugin. https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/")
+			detail := "MANIFEST.txt file not found. Please refer to the documentation for how to sign a plugin. https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/"
+			if !isPublished {
+				detail = "This is a new (unpublished) plugin. This is expected during the initial review process. Please allow the review to continue, and a member of our team will inform you when your plugin can be signed."
+			}
+
+			pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "unsigned plugin", detail)
 			return nil, nil
 		}
 		return nil, err

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes"
-	"github.com/stretchr/testify/assert"
 )
 
 var tests = []struct {
@@ -21,10 +20,11 @@ var tests = []struct {
 		"missing plugin.json",
 		"missing module.js",
 		"missing README.md",
+		"unsigned plugin",
 		"LICENSE file not found",
-		"plugin.json not found",
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
+		"empty manifest",
 		"README.md is empty", "plugin.json: should include screenshots for the Plugin catalog",
 		"plugin.json: (root): type is required",
 		"plugin.json: (root): name is required",
@@ -34,7 +34,6 @@ var tests = []struct {
 		"plugin.json: invalid empty small logo path",
 		"plugin.json: invalid empty large logo path",
 		"LICENSE file not found",
-		"Plugin version \"\" is invalid.",
 	}},
 }
 
@@ -201,27 +200,4 @@ func TestCachedRun(t *testing.T) {
 	if len(res) != 3 {
 		t.Fatal("unexpected results", res)
 	}
-}
-
-func TestDependencyReturnsNil(t *testing.T) {
-	res := make(map[string]interface{})
-
-	parent := &analysis.Analyzer{
-		Name: "parent",
-		Run: func(pass *analysis.Pass) (interface{}, error) {
-			res["parent"] = nil
-			return nil, nil
-		},
-	}
-	firstChild := &analysis.Analyzer{
-		Name:     "firstChild",
-		Requires: []*analysis.Analyzer{parent},
-		Run: func(pass *analysis.Pass) (interface{}, error) {
-			res["firstChild"] = true
-			return true, nil
-		},
-	}
-	_, _ = Check([]*analysis.Analyzer{firstChild}, "", "", Config{Global: GlobalConfig{Enabled: true}})
-
-	assert.Len(t, res, 2)
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -20,11 +20,9 @@ var tests = []struct {
 		"missing plugin.json",
 		"missing module.js",
 		"missing README.md",
-		"unsigned plugin",
 		"LICENSE file not found",
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
-		"empty manifest",
 		"README.md is empty", "plugin.json: should include screenshots for the Plugin catalog",
 		"plugin.json: (root): type is required",
 		"plugin.json: (root): name is required",


### PR DESCRIPTION
New plugins get the same unsigned message as existing plugins that might be confusing for new plugin submitters.

This PR clarifies the message for new plugins
