### PR TITLE
Display the found tracking domain in the validator output

### DIFF
--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -3,6 +3,7 @@ package trackingscripts
 import (
 	"bytes"
 	_ "embed"
+	"fmt"
 	"strings"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -37,7 +38,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	for _, content := range moduleJsMap {
 		for _, url := range servers {
 			if len(url) > 0 && bytes.Contains(content, []byte(url)) {
-				pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code.")
+				pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", fmt.Sprintf("Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: %s", url))
 				hasTrackingScripts = true
 				break
 			}

--- a/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
@@ -45,4 +45,5 @@ func TestTrackingScriptsInvalid(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "module.js: should not include tracking scripts")
+	require.Equal(t, interceptor.Diagnostics[0].Detail, "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: google-analytics.com")
 }


### PR DESCRIPTION
This PR adds which tracking domain was found in the error message when the validator finds one.
