### PR TITLE
Fix panic when metadata is nil in packagejson analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 unpacked_bin/
 __debug_bin
 config/custom.yaml
+.idea

--- a/pkg/analysis/passes/packagejson/packagejson.go
+++ b/pkg/analysis/passes/packagejson/packagejson.go
@@ -33,10 +33,13 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	metadataBody := pass.ResultOf[metadata.Analyzer].([]byte)
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
 
-	var metadata metadata.Metadata
-	if err := json.Unmarshal(metadataBody, &metadata); err != nil {
+	var md metadata.Metadata
+	if err := json.Unmarshal(metadataBody, &md); err != nil {
 		return nil, err
 	}
 
@@ -53,11 +56,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	if parsedPackageJson.Version != metadata.Info.Version {
+	if parsedPackageJson.Version != md.Info.Version {
 		pass.ReportResult(
 			pass.AnalyzerName,
 			packageCodeVersionMisMatch,
-			fmt.Sprintf("The version in package.json (%s) doesn't match the version in plugin.json (%s)", parsedPackageJson.Version, metadata.Info.Version),
+			fmt.Sprintf("The version in package.json (%s) doesn't match the version in plugin.json (%s)", parsedPackageJson.Version, md.Info.Version),
 			"The version in the source code package.json must match the version in plugin.json",
 		)
 		return nil, nil


### PR DESCRIPTION
Fixes https://drone.grafana.net/grafana/community-pipeline/1643 when an archive is improperly structured.

# Before

```
panic: interface conversion: interface {} is nil, not []uint8

goroutine 1 [running]:
github.com/grafana/plugin-validator/pkg/analysis/passes/packagejson.run(0xc0030c1580)
	/home/runner/work/plugin-validator/plugin-validator/pkg/analysis/passes/packagejson/packagejson.go:36 +0x36d
github.com/grafana/plugin-validator/pkg/runner.Check.func2(0x19dd680)
	/home/runner/work/plugin-validator/plugin-validator/pkg/runner/runner.go:79 +0x1aa
github.com/grafana/plugin-validator/pkg/runner.Check.func2(0x19dd260)
	/home/runner/work/plugin-validator/plugin-validator/pkg/runner/runner.go:73 +0xd8
github.com/grafana/plugin-validator/pkg/runner.Check({0x19f1c20, 0x23, 0x23}, {0xc0030b7590, 0xf}, {0xc0030fc6e0, 0x19}, {{0x1, {0xc0030b7448, 0x7}, ...}, ...})
	/home/runner/work/plugin-validator/plugin-validator/pkg/runner/runner.go:89 +0x2d7
main.main()
	/home/runner/work/plugin-validator/plugin-validator/pkg/cmd/plugincheck2/main.go:79 +0x7aa
```

# After

```json
{
  "id": "magnesium-wordcloud-panel",
  "version": "1.1.4",
  "plugin-validator": {
    "archive": [
      {
        "Severity": "ok",
        "Title": "Archive is not empty",
        "Detail": "",
        "Name": "empty-archive"
      },
      {
        "Severity": "error",
        "Title": "Archive contains more than one directory",
        "Detail": "Archive should contain only one directory named after plugin id. Found 2 directories",
        "Name": "more-than-one-dir"
      },
      {
        "Severity": "error",
        "Title": "Plugin archive is improperly structured",
        "Detail": "",
        "Context": "Could not find a plugin.json in the expected located. It is possible your plugin archive structure is incorrect.",
        "Name": "zip-invalid"
      }
    ],
    "code-rules": [
      {
        "Severity": "warning",
        "Title": "semgrep not found in PATH",
        "Detail": "",
        "Name": "semgrep-not-found"
      }
    ],
    "go-sec": [
      {
        "Severity": "warning",
        "Title": "gosec not installed",
        "Detail": "Skipping gosec analysis",
        "Name": "go-sec-not-installed"
      }
    ],
    "tzap-gpt": [
      {
        "Severity": "warning",
        "Title": "OPENAI_API_KEY not found in env",
        "Detail": "Skipping tzap installation",
        "Name": "tzap-gpt-install-error"
      }
    ]
  }
}
```