### PR TITLE
Adding dependabot to keep repo up to date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Changes:

- Adding dependabot config
- Adding a [CODEOWNERS](https://github.com/grafana/plugin-validator/blob/02f3230f28cac9c48658761b51cdf6467b44c80e/.github/CODEOWNERS) file