### PR TITLE
Fix checksum handling of wrong urls

### DIFF
--- a/pkg/analysis/passes/checksum/checksum.go
+++ b/pkg/analysis/passes/checksum/checksum.go
@@ -107,6 +107,11 @@ func resolveCheckSum(checksum string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if len(finalChecksum) == 0 {
+			return "", errors.New(
+				"Checksum URL is invalid. Please provide a URL with a direct download to the checksum.",
+			)
+		}
 		return sanitizeCheckSum(finalChecksum), nil
 	}
 	return sanitizeCheckSum(checksum), nil


### PR DESCRIPTION
Fix an error when the url returns empty content. This can happen if the provided url is to a download service or a page to see the checksum instead of a raw checksum