### PR TITLE
Angular detection: Fetch patterns from GCOM

### DIFF
--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -64,7 +64,6 @@ type gcomPattern struct {
 }
 
 func fetchGcomDetectors() ([]detector, error) {
-
 	resp, err := http.Get("https://grafana.com/api/plugins/angular_patterns")
 	if err != nil {
 		return nil, err

--- a/pkg/analysis/passes/legacyplatform/legacyplatform.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform.go
@@ -110,7 +110,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			break
 		}
 		for _, detector := range legacyDetectors {
-			// for _, detector := range legacyDetectors {
 			if detector.Detect(content) {
 				pass.ReportResult(pass.AnalyzerName, legacyPlatform, "module.js: uses legacy plugin platform", "The plugin uses the legacy plugin platform (AngularJS). Please migrate the plugin to use the new plugins platform.")
 				hasLegacyPlatform = true

--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -40,7 +40,6 @@ var legacyImportTests = []map[string][]byte{
 	{"module.js": []byte(`angular.isNumber(variable)`)},
 	{"module.js": []byte(`editor.html`)},
 	{"module.js": []byte(`ctrl.annotation`)},
-	{"module.js": []byte(`System.register(something)`)},
 }
 
 func TestLegacyPlatformUsesLegacy(t *testing.T) {

--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -33,6 +33,14 @@ var legacyImportTests = []map[string][]byte{
 	{"module.js": []byte(`define(["app/plugins/sdk"],(function(n){return function(n){var t={};function e(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,e),o.l=!0,o.exports}return e.m=n,e.c=t,e.d=function(n,t,r){e.o(n,t)||Object.defineProperty(n,t,{enumerable:!0,get:r})},e.r=function(n){"undefined"!=typeof`)},
 	{"module.js": []byte(`define(["app/plugins/sdk"],(function(n){return function(n){var t={};function e(r){if(t[r])return t[r].exports;var o=t[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,e),o.l=!0,o.exports}return e.m=n,e.c=t,e.d=function(n,t,r){e.o(n,t)||Object.defineProperty(n,t,{enumerable:!0,get:r})},e.r=function(n){"undefined"!=typeof Symbol&&Symbol.toSt`)},
 	{"module.js": []byte(`define(["react","lodash","@grafana/data","@grafana/ui","@emotion/css","@grafana/runtime","moment","app/core/utils/datemath","jquery","app/plugins/sdk","app/core/core_module","app/core/core","app/core/table_model","app/core/utils/kbn","app/core/config","angular"],(function(e,t,r,n,i,a,o,s,u,l,c,p,f,h,d,m){return function(e){var t={};function r(n){if(t[n])return t[n].exports;var i=t[n]={i:n,l:!1,exports:{}};retur`)},
+	{"module.js": []byte(`PanelCtrl`)},
+	{"module.js": []byte(`'QueryCtrl'`)},
+	{"module.js": []byte(`"QueryCtrl"`)},
+	{"module.js": []byte(`import * from 'app/plugins/sdk'`)},
+	{"module.js": []byte(`angular.isNumber(variable)`)},
+	{"module.js": []byte(`editor.html`)},
+	{"module.js": []byte(`ctrl.annotation`)},
+	{"module.js": []byte(`System.register(something)`)},
 }
 
 func TestLegacyPlatformUsesLegacy(t *testing.T) {


### PR DESCRIPTION
## What is this PR about
Fetch patterns from angular detection from GCOM and add simple tests

## Note for reviewers
Not all patterns that were hardcoded are returned by gcom, therefore I only replaced the ones that are returned.
Also the `QueryCtrl` detection is now a little bit different: it's based on a regex and will detect: `"QueryCtrl"` and `'QueryCtrl'`. Before, the hardcoded version was only looking if the `QueryCtrl` was contained.

Closes https://github.com/grafana/plugin-validator/issues/137