### PR TITLE
Add analyzer to check on empty description or keywords

### DIFF
--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/brokenlinks"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/checksum"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/coderules"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/discoverability"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/gomanifest"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/gosec"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/jargon"
@@ -77,4 +78,5 @@ var Analyzers = []*analysis.Analyzer{
 	unsafesvg.Analyzer,
 	version.Analyzer,
 	backenddebug.Analyzer,
+	discoverability.Analyzer,
 }

--- a/pkg/analysis/passes/discoverability/discoverability.go
+++ b/pkg/analysis/passes/discoverability/discoverability.go
@@ -1,0 +1,42 @@
+package discoverability
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+)
+
+var (
+	emptyDescription = &analysis.Rule{Name: "empty-description", Severity: analysis.Warning}
+	emptyKeywords    = &analysis.Rule{Name: "empty-keywords", Severity: analysis.Warning}
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "discoverability",
+	Requires: []*analysis.Analyzer{},
+	Run:      run,
+	Rules:    []*analysis.Rule{},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+
+	var data metadata.Metadata
+	if err := json.Unmarshal(metadataBody, &data); err != nil {
+		return nil, err
+	}
+
+	if data.Info.Description == "" {
+		pass.ReportResult(pass.AnalyzerName, emptyDescription, "plugin.json: description is empty", "Consider providing a plugin description for better discoverability.")
+	}
+
+	if len(data.Info.Keywords) == 0 {
+		pass.ReportResult(pass.AnalyzerName, emptyKeywords, "plugin.json: keywords are empty", "Consider providing plugin keywords for better discoverability.")
+	}
+
+	return nil, nil
+}

--- a/pkg/analysis/passes/discoverability/discoverability.go
+++ b/pkg/analysis/passes/discoverability/discoverability.go
@@ -16,7 +16,7 @@ var Analyzer = &analysis.Analyzer{
 	Name:     "discoverability",
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
-	Rules:    []*analysis.Rule{},
+	Rules:    []*analysis.Rule{emptyDescription, emptyKeywords},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {

--- a/pkg/analysis/passes/discoverability/discoverability.go
+++ b/pkg/analysis/passes/discoverability/discoverability.go
@@ -14,7 +14,7 @@ var (
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "discoverability",
-	Requires: []*analysis.Analyzer{},
+	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
 	Rules:    []*analysis.Rule{},
 }

--- a/pkg/analysis/passes/discoverability/discoverability_test.go
+++ b/pkg/analysis/passes/discoverability/discoverability_test.go
@@ -1,0 +1,60 @@
+package discoverability
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyDescription(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer: []byte(`{"info": {"description": "", "keywords": ["datasource"]}}`),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, interceptor.Diagnostics[0].Title, "plugin.json: description is empty")
+	require.Equal(t, interceptor.Diagnostics[0].Severity, analysis.Warning)
+}
+
+func TestEmptyKeyword(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer: []byte(`{"info": {"description": "Test 123", "keywords": []}}`),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, interceptor.Diagnostics[0].Title, "plugin.json: keywords are empty")
+	require.Equal(t, interceptor.Diagnostics[0].Severity, analysis.Warning)
+}
+
+func TestDiscoverable(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer: []byte(`{"info": {"description": "Test 123", "keywords": ["datasource"]}}`),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}

--- a/pkg/analysis/passes/metadata/types.go
+++ b/pkg/analysis/passes/metadata/types.go
@@ -15,6 +15,8 @@ type MetadataInfo struct {
 	Logos       MetadataLogos         `json:"logos"`
 	Links       []MetadataLink        `json:"links"`
 	Version     string                `json:"version"`
+	Keywords    []string              `json:"keywords"`
+	Description string                `json:"description"`
 }
 
 type MetadataAuthor struct {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -37,6 +37,8 @@ var tests = []struct {
 		"plugin.json: invalid empty large logo path",
 		"LICENSE file not found",
 		"Plugin version \"\" is invalid.",
+		"plugin.json: description is empty",
+		"plugin.json: keywords are empty",
 	}},
 }
 


### PR DESCRIPTION
Add new analyzer to warn on empty descriptions or empty keywords, this is made to allow encourage authors to provide data for better plugin discoverability.

Closes https://github.com/grafana/plugin-validator/issues/167