### PR TITLE
CI: Update GitHub Action to build Docker container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,26 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and test Docker container
+        uses: docker/build-push-action@v5
         with:
-          go-version: "~1.21"
-          check-latest: true
-
-      - name: Install dependencies
-        run: go get .
-
-      - name: Install semgrep
-        run: python3 -m pip install semgrep
-
-      - name: Install gosec
-        run: wget -O - -q https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.18.2
-
-      - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-
-      - name: Build with Mage
-        uses: magefile/mage-action@v3
-        with:
-          version: latest
-          args: -v build:ci
+          context: .
+          push: false


### PR DESCRIPTION
Updates the GitHub Action `test.yml` so it builds the Docker container, rather than running the tests and build step directly inside GitHub Actions.

Right now, the GitHub Action is doing the same steps as the ones in the Dockerfile:
https://github.com/grafana/plugin-validator/blob/45b483c582796386aef38b435252b7c744a49bd9/Dockerfile#L1-L16

With this PR, the GH action will trigger a Docker image build. This is better because whenever we change the build/test steps (or the golangci-lint, semgrep or gosec versions), we don't have to update the GH action workflow as well as the Dockerfile.

This is also the same approach used in the drone pipeline, where the "build + test + push" step simply builds the Docker container:

https://github.com/grafana/plugin-validator/blob/45b483c582796386aef38b435252b7c744a49bd9/.drone.yml#L4-L14