### PR TITLE
New Validator: Add sdk usage validation for plugins with a backend component

### DIFF
--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/restrictivedep"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/screenshots"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sdkusage"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/signature"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/templatereadme"
@@ -79,4 +80,5 @@ var Analyzers = []*analysis.Analyzer{
 	version.Analyzer,
 	backenddebug.Analyzer,
 	discoverability.Analyzer,
+	sdkusage.Analyzer,
 }

--- a/pkg/analysis/passes/sdkusage/sdkusage.go
+++ b/pkg/analysis/passes/sdkusage/sdkusage.go
@@ -1,0 +1,104 @@
+package sdkusage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"golang.org/x/mod/modfile"
+)
+
+var (
+	goSdkNotUsed  = &analysis.Rule{Name: "go-sdk-not-used", Severity: analysis.Error}
+	goModNotFound = &analysis.Rule{Name: "go-mod-not-found", Severity: analysis.Error}
+)
+
+// Analyzer is an analyzer that checks if backend standalone debug files are included in the executable.
+// If so, it reports an error, as the plugin can't be used properly in non-debug mode.
+var Analyzer = &analysis.Analyzer{
+	Name:     "backenddebug",
+	Requires: []*analysis.Analyzer{sourcecode.Analyzer, metadata.Analyzer},
+	Run:      run,
+	Rules:    []*analysis.Rule{goSdkNotUsed, goModNotFound},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+
+	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
+	if !ok {
+		// no source code found so we can't go.mod
+		return nil, nil
+	}
+	metadataBody, ok := pass.ResultOf[metadata.Analyzer].([]byte)
+	if !ok {
+		return nil, nil
+	}
+
+	var data metadata.Metadata
+	if err := json.Unmarshal(metadataBody, &data); err != nil {
+		return nil, err
+	}
+
+	if !data.Backend && data.Executable == "" {
+		// Do not perform check for plugins without a backend declared
+		return nil, nil
+	}
+
+	goModPath := filepath.Join(sourceCodeDir, "go.mod")
+	// check if go.mod exists
+	if _, err := os.Stat(goModPath); err != nil {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			goModNotFound,
+			"go.mod can not be found in your source code",
+			"You have indicated your plugin uses a backend (backend=true), but go.mod can not be found in your source code. If your plugin has a backend component you must use go (golang)",
+		)
+		// go.mod not found
+		return nil, nil
+	}
+
+	goModContent, err := os.ReadFile(goModPath)
+	if err != nil {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			goModNotFound,
+			"go.mod can not be read from your source code",
+			"You have indicated your plugin uses a backend (backend=true), but go.mod can not be read from your source code. If your plugin has a backend component you must use go (golang)",
+		)
+		return nil, nil
+	}
+
+	goModParsed, err := modfile.Parse("go.mod", goModContent, nil)
+
+	if err != nil {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			goModNotFound,
+			"go.mod can not be parsed from your source code",
+			"You have indicated your plugin uses a backend (backend=true), but go.mod can not be parsed from your source code. If your plugin has a backend component you must use go (golang)",
+		)
+		return nil, nil
+	}
+	hasGoSdk := false
+
+	for _, req := range goModParsed.Require {
+		if req.Mod.Path == "github.com/grafana/grafana-plugin-sdk-go" {
+			hasGoSdk = true
+		}
+	}
+
+	if !hasGoSdk {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			goSdkNotUsed,
+			"Your plugin uses a backend (backend=true), but the Grafana go sdk is not used",
+			"If your plugin has a backend component you must use Grafana go sdk (github.com/grafana/grafana-plugin-sdk-go)",
+		)
+		return nil, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/analysis/passes/sdkusage/sdkusage.go
+++ b/pkg/analysis/passes/sdkusage/sdkusage.go
@@ -16,8 +16,6 @@ var (
 	goModNotFound = &analysis.Rule{Name: "go-mod-not-found", Severity: analysis.Error}
 )
 
-// Analyzer is an analyzer that checks if backend standalone debug files are included in the executable.
-// If so, it reports an error, as the plugin can't be used properly in non-debug mode.
 var Analyzer = &analysis.Analyzer{
 	Name:     "backenddebug",
 	Requires: []*analysis.Analyzer{sourcecode.Analyzer, metadata.Analyzer},

--- a/pkg/analysis/passes/sdkusage/sdkusage.go
+++ b/pkg/analysis/passes/sdkusage/sdkusage.go
@@ -17,7 +17,7 @@ var (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name:     "backenddebug",
+	Name:     "sdkusage",
 	Requires: []*analysis.Analyzer{sourcecode.Analyzer, metadata.Analyzer},
 	Run:      run,
 	Rules:    []*analysis.Rule{goSdkNotUsed, goModNotFound},

--- a/pkg/analysis/passes/sdkusage/sdkusage_test.go
+++ b/pkg/analysis/passes/sdkusage/sdkusage_test.go
@@ -1,0 +1,111 @@
+package sdkusage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoModNotFound(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	const pluginJsonContent = `{
+    "name": "my plugin name",
+    "backend": true,
+    "executable": "gx_plugin"
+  }`
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer:   []byte(pluginJsonContent),
+			sourcecode.Analyzer: filepath.Join("testdata", "nogomod"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"go.mod can not be found in your source code",
+		interceptor.Diagnostics[0].Title,
+	)
+}
+
+func TestGoModNotParseable(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	const pluginJsonContent = `{
+    "name": "my plugin name",
+    "backend": true,
+    "executable": "gx_plugin"
+  }`
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer:   []byte(pluginJsonContent),
+			sourcecode.Analyzer: filepath.Join("testdata", "gomodwrong"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"go.mod can not be parsed from your source code",
+		interceptor.Diagnostics[0].Title,
+	)
+}
+
+func TestValidGoMod(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	const pluginJsonContent = `{
+    "name": "my plugin name",
+    "backend": true,
+    "executable": "gx_plugin"
+  }`
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer:   []byte(pluginJsonContent),
+			sourcecode.Analyzer: filepath.Join("testdata", "validgomod"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestValidGoModWithNoGrafanaSdk(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	const pluginJsonContent = `{
+    "name": "my plugin name",
+    "backend": true,
+    "executable": "gx_plugin"
+  }`
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			metadata.Analyzer:   []byte(pluginJsonContent),
+			sourcecode.Analyzer: filepath.Join("testdata", "nografanagosdk"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"Your plugin uses a backend (backend=true), but the Grafana go sdk is not used",
+		interceptor.Diagnostics[0].Title,
+	)
+}

--- a/pkg/analysis/passes/sdkusage/testdata/gomodwrong/go.mod
+++ b/pkg/analysis/passes/sdkusage/testdata/gomodwrong/go.mod
@@ -1,0 +1,1 @@
+mock content for a gomod file that can't be parsed

--- a/pkg/analysis/passes/sdkusage/testdata/nografanagosdk/go.mod
+++ b/pkg/analysis/passes/sdkusage/testdata/nografanagosdk/go.mod
@@ -1,0 +1,19 @@
+module github.com/grafana/grafana-testinggomod-datasource
+
+go 1.22
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1
+	github.com/grafana/grafana-aws-sdk v0.24.0
+	github.com/icholy/digest v0.1.22
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/oauth2 v0.18.0
+	moul.io/http2curl v1.0.0
+)
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+)

--- a/pkg/analysis/passes/sdkusage/testdata/validgomod/go.mod
+++ b/pkg/analysis/passes/sdkusage/testdata/validgomod/go.mod
@@ -1,0 +1,20 @@
+module github.com/grafana/grafana-testinggomod-datasource
+
+go 1.22
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1
+	github.com/grafana/grafana-aws-sdk v0.24.0
+	github.com/grafana/grafana-plugin-sdk-go v0.225.0
+	github.com/icholy/digest v0.1.22
+	github.com/stretchr/testify v1.9.0
+	golang.org/x/oauth2 v0.18.0
+	moul.io/http2curl v1.0.0
+)
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+)


### PR DESCRIPTION
Adds the code to validate if the plugin has a backend component it should use the grafana go sdk


Note: Currently not taking in consideration nested plugins. That is to come in a follow up PR