### PR TITLE
Meta-data schema validator: Use the current plugin.json schema

### DIFF
--- a/pkg/analysis/passes/metadataschema/metadataschema.go
+++ b/pkg/analysis/passes/metadataschema/metadataschema.go
@@ -12,7 +12,7 @@ var Analyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
-const schemaURL = "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json"
+const schemaURL = "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json"
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	resp, err := http.Get(schemaURL)


### PR DESCRIPTION
### What changed?
Updated the plugin.json schema validator to use the schema from the `main` branch instead of the old `master` one.