### PR TITLE
Update legacyplatform_test.go

### DIFF
--- a/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
+++ b/pkg/analysis/passes/legacyplatform/legacyplatform_test.go
@@ -38,7 +38,6 @@ var legacyImportTests = []map[string][]byte{
 	{"module.js": []byte(`"QueryCtrl"`)},
 	{"module.js": []byte(`import * from 'app/plugins/sdk'`)},
 	{"module.js": []byte(`angular.isNumber(variable)`)},
-	{"module.js": []byte(`editor.html`)},
 	{"module.js": []byte(`ctrl.annotation`)},
 }
 


### PR DESCRIPTION
Remove  `editor.html` as we are not longer using this pattern