### PR TITLE
New validator: Validate includes property for plugins with nested plugins

### DIFF
--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/discoverability"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/gomanifest"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/gosec"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/includesnested"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/jargon"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/jssourcemap"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/legacybuilder"
@@ -47,24 +48,29 @@ import (
 var Analyzers = []*analysis.Analyzer{
 	archive.Analyzer,
 	archivename.Analyzer,
-	brokenlinks.Analyzer,
+	backendbinary.Analyzer,
+	backenddebug.Analyzer,
 	binarypermissions.Analyzer,
+	brokenlinks.Analyzer,
 	checksum.Analyzer,
 	coderules.Analyzer,
-	gosec.Analyzer,
+	discoverability.Analyzer,
 	gomanifest.Analyzer,
+	gosec.Analyzer,
+	includesnested.Analyzer,
 	jargon.Analyzer,
 	jssourcemap.Analyzer,
-	legacyplatform.Analyzer,
 	legacybuilder.Analyzer,
-	logos.Analyzer,
+	legacyplatform.Analyzer,
 	license.Analyzer,
 	llmreview.Analyzer,
+	logos.Analyzer,
 	manifest.Analyzer,
 	metadata.Analyzer,
 	metadatapaths.Analyzer,
 	metadatavalid.Analyzer,
 	modulejs.Analyzer,
+	nestedmetadata.Analyzer,
 	org.Analyzer,
 	osvscanner.Analyzer,
 	packagejson.Analyzer,
@@ -73,6 +79,7 @@ var Analyzers = []*analysis.Analyzer{
 	readme.Analyzer,
 	restrictivedep.Analyzer,
 	screenshots.Analyzer,
+	sdkusage.Analyzer,
 	signature.Analyzer,
 	sourcecode.Analyzer,
 	templatereadme.Analyzer,
@@ -80,9 +87,4 @@ var Analyzers = []*analysis.Analyzer{
 	typesuffix.Analyzer,
 	unsafesvg.Analyzer,
 	version.Analyzer,
-	backenddebug.Analyzer,
-	discoverability.Analyzer,
-	backendbinary.Analyzer,
-	sdkusage.Analyzer,
-	nestedmetadata.Analyzer,
 }

--- a/pkg/analysis/passes/includesnested/includesnested.go
+++ b/pkg/analysis/passes/includesnested/includesnested.go
@@ -105,7 +105,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					key,
 				),
 				fmt.Sprintf(
-					"Found a plugin %s nested inside your archive but not declared in plugin.json",
+					"Found a plugin %s nested inside your archive but not declared in plugin.json. Make sure to declare the type and path of the nested plugin",
 					key,
 				),
 			)

--- a/pkg/analysis/passes/includesnested/includesnested.go
+++ b/pkg/analysis/passes/includesnested/includesnested.go
@@ -1,0 +1,116 @@
+package includesnested
+
+import (
+	"fmt"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/nestedmetadata"
+)
+
+var (
+	nestedPluginNotDeclared = &analysis.Rule{
+		Name:     "nested-plugins-not-declared",
+		Severity: analysis.Error,
+	}
+	nestedPluginMissingType = &analysis.Rule{
+		Name:     "nested-plugin-missing-type",
+		Severity: analysis.Error,
+	}
+	nestedPluginTypeMissmatch = &analysis.Rule{
+		Name:     "nested-plugin-type-missmatch",
+		Severity: analysis.Error,
+	}
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "includesnested",
+	Requires: []*analysis.Analyzer{archive.Analyzer, nestedmetadata.Analyzer},
+	Run:      run,
+	Rules: []*analysis.Rule{
+		nestedPluginNotDeclared,
+		nestedPluginMissingType,
+		nestedPluginTypeMissmatch,
+	},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+
+	metadatamap, ok := pass.ResultOf[nestedmetadata.Analyzer].(nestedmetadata.Metadatamap)
+	if !ok {
+		return nil, nil
+	}
+
+	if len(metadatamap) == 1 {
+		// no nested plugins
+		return nil, nil
+	}
+
+	// this should never happen and the nested validator should
+	// have catched it before. Adding it to be safe
+	if _, ok := metadatamap["plugin.json"]; !ok {
+		return nil, nil
+	}
+
+	includes := metadatamap["plugin.json"].Includes
+
+	for key := range metadatamap {
+		if key == "plugin.json" {
+			// skip main plugin.json
+			continue
+		}
+		found := false
+		for _, include := range includes {
+			if include.Path == key {
+				found = true
+
+				if include.Type == "" {
+					pass.ReportResult(
+						pass.AnalyzerName,
+						nestedPluginMissingType,
+						fmt.Sprintf(
+							"Nested plugin %s is missing type",
+							key,
+						),
+						fmt.Sprintf(
+							"Found a plugin %s declared in your main plugin.json without a type",
+							key,
+						),
+					)
+				} else if include.Type != metadatamap[key].Type {
+					pass.ReportResult(
+						pass.AnalyzerName,
+						nestedPluginTypeMissmatch,
+						fmt.Sprintf(
+							"Nested plugin %s has a type missmatch",
+							key,
+						),
+						fmt.Sprintf(
+							"Plugin %s declared in your main plugin.json as %s but as %s in your main plugin.json",
+							key,
+							include.Type,
+							metadatamap[key].Type,
+						),
+					)
+				}
+				continue
+			}
+		}
+		if !found {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				nestedPluginNotDeclared,
+				fmt.Sprintf(
+					"Nested plugin %s is not declared in plugin main plugin.json",
+					key,
+				),
+				fmt.Sprintf(
+					"Found a plugin %s nested inside your archive but not declared in plugin.json",
+					key,
+				),
+			)
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/analysis/passes/includesnested/includesnested.go
+++ b/pkg/analysis/passes/includesnested/includesnested.go
@@ -34,7 +34,7 @@ var Analyzer = &analysis.Analyzer{
 	Rules: []*analysis.Rule{
 		nestedPluginNotDeclared,
 		nestedPluginMissingType,
-		nestedPluginTypeMissmatch,
+		nestedPluginTypeMismatch,
 		nestedPlugidInNonApp,
 	},
 }
@@ -92,20 +92,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 							key,
 						),
 						fmt.Sprintf(
-							"Found a plugin %s declared in your main plugin.json without a type",
+							"Found a plugin %s declared in parent plugin.json without a type",
 							key,
 						),
 					)
 				} else if include.Type != metadatamap[key].Type {
 					pass.ReportResult(
 						pass.AnalyzerName,
-						nestedPluginTypeMissmatch,
+						nestedPluginTypeMismatch,
 						fmt.Sprintf(
 							"Nested plugin %s has a type missmatch",
 							key,
 						),
 						fmt.Sprintf(
-							"Plugin %s declared in your main plugin.json as %s but as %s in your main plugin.json",
+							"Plugin %s declared as %s but as %s in parent plugin.json",
 							key,
 							include.Type,
 							metadatamap[key].Type,
@@ -120,7 +120,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				pass.AnalyzerName,
 				nestedPluginNotDeclared,
 				fmt.Sprintf(
-					"Nested plugin %s is not declared in plugin main plugin.json",
+					"Nested plugin %s is not declared parent plugin.json",
 					key,
 				),
 				fmt.Sprintf(

--- a/pkg/analysis/passes/includesnested/includesnested.go
+++ b/pkg/analysis/passes/includesnested/includesnested.go
@@ -21,6 +21,10 @@ var (
 		Name:     "nested-plugin-type-missmatch",
 		Severity: analysis.Error,
 	}
+	nestedPlugidInNonApp = &analysis.Rule{
+		Name:     "nested-plugin-id-in-non-app",
+		Severity: analysis.Error,
+	}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -31,6 +35,7 @@ var Analyzer = &analysis.Analyzer{
 		nestedPluginNotDeclared,
 		nestedPluginMissingType,
 		nestedPluginTypeMissmatch,
+		nestedPlugidInNonApp,
 	},
 }
 
@@ -50,6 +55,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// have catched it before. Adding it to be safe
 	if _, ok := metadatamap["plugin.json"]; !ok {
 		return nil, nil
+	}
+
+	if metadatamap["plugin.json"].Type != "app" && len(metadatamap) > 1 {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			nestedPlugidInNonApp,
+			fmt.Sprintf(
+				"Nested plugins are not allowed on plugins type %s",
+				metadatamap["plugin.json"].Type,
+			),
+			"A nested plugin was found in your archive but your plugin is not an app plugin",
+		)
+		return nil, nil
+
 	}
 
 	includes := metadatamap["plugin.json"].Includes

--- a/pkg/analysis/passes/includesnested/includesnested.go
+++ b/pkg/analysis/passes/includesnested/includesnested.go
@@ -17,7 +17,7 @@ var (
 		Name:     "nested-plugin-missing-type",
 		Severity: analysis.Error,
 	}
-	nestedPluginTypeMissmatch = &analysis.Rule{
+	nestedPluginTypeMismatch = &analysis.Rule{
 		Name:     "nested-plugin-type-missmatch",
 		Severity: analysis.Error,
 	}

--- a/pkg/analysis/passes/includesnested/includesnested_test.go
+++ b/pkg/analysis/passes/includesnested/includesnested_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidCorrectIncludesDefinition(t *testing.T) {
+func TestValidIncludesDefinition(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pluginJsonContent := []byte(`{
 		"id": "test-plugin-app",
@@ -72,6 +72,7 @@ func TestValidCorrectIncludesDefinition(t *testing.T) {
 
 func TestMissingIncludeNested(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
+	// missing the nested datasource
 	pluginJsonContent := []byte(`{
 		"id": "test-plugin-app",
 		"type": "app",
@@ -129,6 +130,8 @@ func TestMissingIncludeNested(t *testing.T) {
 }
 
 func TestMissingIncludeTypeNested(t *testing.T) {
+
+	// missing the type of the nested panel
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pluginJsonContent := []byte(`{
 				"id": "test-plugin-app",
@@ -210,6 +213,8 @@ func TestIncludedNestedTypeMissmatch(t *testing.T) {
     ]
   }`)
 
+	// declared as datasource in the included
+	// but has panel type
 	bundled1JsonContent := []byte(`{
     "id": "test-plugin-datasource",
     "type": "panel",

--- a/pkg/analysis/passes/includesnested/includesnested_test.go
+++ b/pkg/analysis/passes/includesnested/includesnested_test.go
@@ -1,0 +1,261 @@
+package includesnested
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/nestedmetadata"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+	"github.com/grafana/plugin-validator/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidCorrectIncludesDefinition(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pluginJsonContent := []byte(`{
+		"id": "test-plugin-app",
+		"type": "app",
+		"includes": [
+      {
+        "type": "datasource",
+        "name": "Nested data source",
+        "path": "nested-datasource/plugin.json"
+      },
+      {
+        "type": "panel",
+        "name": "nested panel",
+        "path": "nested-panel/plugin.json"
+      }
+    ]
+  }`)
+
+	bundled1JsonContent := []byte(`{
+    "id": "test-plugin-datasource",
+    "type": "datasource",
+    "name": "nested datasource"
+  }`)
+
+	bundled2JsonContent := []byte(`{
+    "id": "test-plugin-panel",
+    "type": "panel",
+    "name": "nested panel"
+  }`)
+
+	mainMeta, err := utils.JSONToMetadata(pluginJsonContent)
+	require.NoError(t, err)
+
+	bundle1Meta, err := utils.JSONToMetadata(bundled1JsonContent)
+	require.NoError(t, err)
+
+	bundle2Meta, err := utils.JSONToMetadata(bundled2JsonContent)
+	require.NoError(t, err)
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("./"),
+			nestedmetadata.Analyzer: nestedmetadata.Metadatamap{
+				"plugin.json":                   mainMeta,
+				"nested-datasource/plugin.json": bundle1Meta,
+				"nested-panel/plugin.json":      bundle2Meta,
+			},
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestMissingIncludeNested(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pluginJsonContent := []byte(`{
+		"id": "test-plugin-app",
+		"type": "app",
+		"includes": [
+      {
+        "type": "panel",
+        "name": "nested panel",
+        "path": "nested-panel/plugin.json"
+      }
+    ]
+  }`)
+
+	bundled1JsonContent := []byte(`{
+    "id": "test-plugin-datasource",
+    "type": "datasource",
+    "name": "nested datasource"
+  }`)
+
+	bundled2JsonContent := []byte(`{
+    "id": "test-plugin-panel",
+    "type": "panel",
+    "name": "nested panel"
+  }`)
+
+	mainMeta, err := utils.JSONToMetadata(pluginJsonContent)
+	require.NoError(t, err)
+
+	bundle1Meta, err := utils.JSONToMetadata(bundled1JsonContent)
+	require.NoError(t, err)
+
+	bundle2Meta, err := utils.JSONToMetadata(bundled2JsonContent)
+	require.NoError(t, err)
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("./"),
+			nestedmetadata.Analyzer: nestedmetadata.Metadatamap{
+				"plugin.json":                   mainMeta,
+				"nested-datasource/plugin.json": bundle1Meta,
+				"nested-panel/plugin.json":      bundle2Meta,
+			},
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"Nested plugin nested-datasource/plugin.json is not declared in plugin main plugin.json",
+		interceptor.Diagnostics[0].Title,
+	)
+}
+
+func TestMissingIncludeTypeNested(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pluginJsonContent := []byte(`{
+				"id": "test-plugin-app",
+		"type": "app",
+		"includes": [
+      {
+        "type": "datasource",
+        "name": "Nested data source",
+        "path": "nested-datasource/plugin.json"
+      },
+      {
+        "name": "nested panel",
+        "path": "nested-panel/plugin.json"
+      }
+    ]
+  }`)
+
+	bundled1JsonContent := []byte(`{
+    "id": "test-plugin-datasource",
+    "type": "datasource",
+    "name": "nested datasource"
+  }`)
+
+	//missing panel type
+	bundled2JsonContent := []byte(`{
+    "id": "test-plugin-panel",
+    "name": "nested panel",
+    "type": "panel"
+  }`)
+
+	mainMeta, err := utils.JSONToMetadata(pluginJsonContent)
+	require.NoError(t, err)
+
+	bundle1Meta, err := utils.JSONToMetadata(bundled1JsonContent)
+	require.NoError(t, err)
+
+	bundle2Meta, err := utils.JSONToMetadata(bundled2JsonContent)
+	require.NoError(t, err)
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("./"),
+			nestedmetadata.Analyzer: nestedmetadata.Metadatamap{
+				"plugin.json":                   mainMeta,
+				"nested-datasource/plugin.json": bundle1Meta,
+				"nested-panel/plugin.json":      bundle2Meta,
+			},
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"Nested plugin nested-panel/plugin.json is missing type",
+		interceptor.Diagnostics[0].Title,
+	)
+}
+
+func TestIncludedNestedTypeMissmatch(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pluginJsonContent := []byte(`{
+		"id": "test-plugin-app",
+		"type": "app",
+		"includes": [
+      {
+        "type": "datasource",
+        "name": "Nested data source",
+        "path": "nested-datasource/plugin.json"
+      },
+      {
+        "type": "panel",
+        "name": "nested panel",
+        "path": "nested-panel/plugin.json"
+      }
+    ]
+  }`)
+
+	bundled1JsonContent := []byte(`{
+    "id": "test-plugin-datasource",
+    "type": "panel",
+    "name": "nested datasource"
+  }`)
+
+	bundled2JsonContent := []byte(`{
+    "id": "test-plugin-panel",
+    "type": "panel",
+    "name": "nested panel"
+  }`)
+
+	mainMeta, err := utils.JSONToMetadata(pluginJsonContent)
+	require.NoError(t, err)
+
+	bundle1Meta, err := utils.JSONToMetadata(bundled1JsonContent)
+	require.NoError(t, err)
+
+	bundle2Meta, err := utils.JSONToMetadata(bundled2JsonContent)
+	require.NoError(t, err)
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("./"),
+			nestedmetadata.Analyzer: nestedmetadata.Metadatamap{
+				"plugin.json":                   mainMeta,
+				"nested-datasource/plugin.json": bundle1Meta,
+				"nested-panel/plugin.json":      bundle2Meta,
+			},
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"Nested plugin nested-datasource/plugin.json has a type missmatch",
+		interceptor.Diagnostics[0].Title,
+	)
+
+	require.Equal(
+		t,
+		"Plugin nested-datasource/plugin.json declared in your main plugin.json as datasource but as panel in your main plugin.json",
+		interceptor.Diagnostics[0].Detail,
+	)
+}

--- a/pkg/analysis/passes/includesnested/includesnested_test.go
+++ b/pkg/analysis/passes/includesnested/includesnested_test.go
@@ -124,7 +124,7 @@ func TestMissingIncludeNested(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(
 		t,
-		"Nested plugin nested-datasource/plugin.json is not declared in plugin main plugin.json",
+		"Nested plugin nested-datasource/plugin.json is not declared parent plugin.json",
 		interceptor.Diagnostics[0].Title,
 	)
 }
@@ -260,7 +260,7 @@ func TestIncludedNestedTypeMissmatch(t *testing.T) {
 
 	require.Equal(
 		t,
-		"Plugin nested-datasource/plugin.json declared in your main plugin.json as datasource but as panel in your main plugin.json",
+		"Plugin nested-datasource/plugin.json declared as datasource but as panel in parent plugin.json",
 		interceptor.Diagnostics[0].Detail,
 	)
 }

--- a/pkg/analysis/passes/metadata/types.go
+++ b/pkg/analysis/passes/metadata/types.go
@@ -1,13 +1,14 @@
 package metadata
 
 type Metadata struct {
-	ID         string       `json:"id"`
-	Name       string       `json:"name"`
-	Type       string       `json:"type"`
-	Info       MetadataInfo `json:"info"`
-	Executable string       `json:"executable"`
-	Backend    bool         `json:"backend"`
-	Alerting   bool         `json:"alerting"`
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Info       MetadataInfo       `json:"info"`
+	Includes   []MetatadaIncludes `json:"includes"`
+	Executable string             `json:"executable"`
+	Backend    bool               `json:"backend"`
+	Alerting   bool               `json:"alerting"`
 }
 
 type MetadataInfo struct {
@@ -37,4 +38,17 @@ type MetadataLogos struct {
 type MetadataLink struct {
 	Name string `json:"name"`
 	URL  string `json:"url"`
+}
+
+type MetatadaIncludes struct {
+	Action     string `json:"action"`
+	AddToNav   bool   `json:"addToNav"`
+	Component  string `json:"component"`
+	DefaultNav bool   `json:"defaultNav"`
+	Icon       string `json:"icon"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	Role       string `json:"role"`
+	Type       string `json:"type"`
+	Uid        string `json:"uid"`
 }

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -78,6 +78,20 @@ func TestIntegration(t *testing.T) {
 						Name:     "invalid-metadata",
 					},
 				},
+				"includesnested": {
+					{
+						Severity: "error",
+						Title:    "Nested plugin datasource/plugin.json is not declared in plugin main plugin.json",
+						Detail:   "Found a plugin datasource/plugin.json nested inside your archive but not declared in plugin.json. Make sure to declare the type and path of the nested plugin",
+						Name:     "nested-plugins-not-declared",
+					},
+					{
+						Severity: "error",
+						Title:    "Nested plugin panel-triggers/plugin.json is not declared in plugin main plugin.json",
+						Detail:   "Found a plugin panel-triggers/plugin.json nested inside your archive but not declared in plugin.json. Make sure to declare the type and path of the nested plugin",
+						Name:     "nested-plugins-not-declared",
+					},
+				},
 			},
 		},
 		"yesoreyeram-infinity-datasource-2.6.3.linux_amd64.zip": {

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -81,13 +81,13 @@ func TestIntegration(t *testing.T) {
 				"includesnested": {
 					{
 						Severity: "error",
-						Title:    "Nested plugin datasource/plugin.json is not declared in plugin main plugin.json",
+						Title:    "Nested plugin datasource/plugin.json is not declared parent plugin.json",
 						Detail:   "Found a plugin datasource/plugin.json nested inside your archive but not declared in plugin.json. Make sure to declare the type and path of the nested plugin",
 						Name:     "nested-plugins-not-declared",
 					},
 					{
 						Severity: "error",
-						Title:    "Nested plugin panel-triggers/plugin.json is not declared in plugin main plugin.json",
+						Title:    "Nested plugin panel-triggers/plugin.json is not declared parent plugin.json",
 						Detail:   "Found a plugin panel-triggers/plugin.json nested inside your archive but not declared in plugin.json. Make sure to declare the type and path of the nested plugin",
 						Name:     "nested-plugins-not-declared",
 					},


### PR DESCRIPTION
New validator for app plugins with nested plugins to declare the dependencies correctly in the `includes` property of their `plugin.json`
