### PR TITLE
Fix source code validation with windows line ending

### DIFF
--- a/pkg/analysis/passes/gomanifest/gomanifest.go
+++ b/pkg/analysis/passes/gomanifest/gomanifest.go
@@ -191,7 +191,7 @@ func hashFileContent(path string) (string, string, error) {
 	linuxHash := hex.EncodeToString(hLinux[:])
 
 	// Normalize data to Windows line endings and calculate the hash
-	windowsLineEndData := strings.ReplaceAll(string(data), "\n", "\r\n")
+	windowsLineEndData := strings.ReplaceAll(string(linuxLineEndData), "\n", "\r\n")
 	hWindows := sha256.Sum256([]byte(windowsLineEndData))
 	windowsHash := hex.EncodeToString(hWindows[:])
 

--- a/pkg/analysis/passes/gomanifest/gomanifest_test.go
+++ b/pkg/analysis/passes/gomanifest/gomanifest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"github.com/grafana/plugin-validator/pkg/prettyprint"
 	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
 	"github.com/stretchr/testify/require"
 )
@@ -84,7 +85,11 @@ func TestIncorrectManifest(t *testing.T) {
 	_, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "The Go build manifest does not match the source code")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"The Go build manifest does not match the source code",
+	)
 }
 
 func TestMissingFileInManifest(t *testing.T) {
@@ -102,7 +107,11 @@ func TestMissingFileInManifest(t *testing.T) {
 	_, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "The Go build manifest does not match the source code")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"The Go build manifest does not match the source code",
+	)
 }
 
 func TestMissingFileInSourceCode(t *testing.T) {
@@ -120,7 +129,11 @@ func TestMissingFileInSourceCode(t *testing.T) {
 	_, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "The Go build manifest does not match the source code")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"The Go build manifest does not match the source code",
+	)
 }
 
 func TestNoBackend(t *testing.T) {
@@ -153,5 +166,22 @@ func TestWindowsManifest(t *testing.T) {
 	}
 	_, err := Analyzer.Run(pass)
 	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestWindowsLineEndingsManifest(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer:    filepath.Join("testdata", "windows-line-endings", "dist"),
+			sourcecode.Analyzer: filepath.Join("testdata", "windows-line-endings", "src"),
+			metadata.Analyzer:   pluginJSONWithBackend,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	prettyprint.Print(interceptor.Diagnostics)
 	require.Len(t, interceptor.Diagnostics, 0)
 }

--- a/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/dist/go_plugin_build_manifest
+++ b/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/dist/go_plugin_build_manifest
@@ -1,0 +1,2 @@
+3f13ad9cffcc761e844ec7c7d21cc757f37049212920874ed0e8328bbe5bf1bf:pkg\main.go
+c320b8e8df08a5337d081175e1e9f961c8f0b8f9cd46fcef397c24aef79ae0ad:pkg\subdir\subfile.go

--- a/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/src/pkg/main.go
+++ b/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/src/pkg/main.go
@@ -1,0 +1,14 @@
+package src
+
+// IMPORTANT!!!
+// IMPORTANT!!!
+
+// DO NOT EDIT OR SAVE THIS FILE IN A MAC OR LINUX SYSTEM
+// IT WILL CHANGE THE WINDOWS LINE ENDINGS TO UNIX LINE ENDINGS
+
+// IMPORTANT!!!
+// IMPORTANT!!!
+
+func main() {
+	panic("do not include this. this is a test file only")
+}

--- a/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/src/pkg/subdir/subfile.go
+++ b/pkg/analysis/passes/gomanifest/testdata/windows-line-endings/src/pkg/subdir/subfile.go
@@ -1,0 +1,14 @@
+package subdir
+
+// IMPORTANT!!!
+// IMPORTANT!!!
+
+// DO NOT EDIT OR SAVE THIS FILE IN A MAC OR LINUX SYSTEM
+// IT WILL CHANGE THE WINDOWS LINE ENDINGS TO UNIX LINE ENDINGS
+
+// IMPORTANT!!!
+// IMPORTANT!!!
+
+func MyFunction() {
+	panic("do not include this. this is a test file only")
+}


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-validator/issues/205

Fixes an issue where the validator will fail to compare files that were saved in windows against files that were saved on linux.

This occurs when the archive was created with line endings that were different on linux and windows.

There's no risk on having a false positive or no detecting changes because js files are normalized to unix line endings or windows line endings before comparison
but the content stays the same.
