### PR TITLE
New Validator: ClamAV virus scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ARG SEMGREP_VERSION
 WORKDIR /go/src/github.com/grafana/plugin-validator
 ADD . /go/src/github.com/grafana/plugin-validator
 
-RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip && \
-    update-ca-certificates
+RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip clamav
+RUN update-ca-certificates
+RUN freshclam
 
 RUN git clone https://github.com/magefile/mage --depth 1 && \
     cd mage && \
@@ -30,13 +31,15 @@ FROM alpine:3.19
 ARG GOSEC_VERSION
 ARG SEMGREP_VERSION
 
-RUN apk add --no-cache git ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk && \
-    update-ca-certificates
+RUN apk add --no-cache git ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav
+RUN update-ca-certificates
+RUN freshclam
 
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b /usr/local/bin ${GOSEC_VERSION}
 
 # install semgrep
 RUN python3 -m pip install semgrep==${SEMGREP_VERSION} --ignore-installed --break-system-packages
+
 
 WORKDIR /app
 COPY --from=builder /go/src/github.com/grafana/plugin-validator/bin bin

--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/typesuffix"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/version"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/virusscan"
 )
 
 var Analyzers = []*analysis.Analyzer{
@@ -87,4 +88,5 @@ var Analyzers = []*analysis.Analyzer{
 	typesuffix.Analyzer,
 	unsafesvg.Analyzer,
 	version.Analyzer,
+	virusscan.Analyzer,
 }

--- a/pkg/analysis/passes/virusscan/testdata/invalid/main.go
+++ b/pkg/analysis/passes/virusscan/testdata/invalid/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("This is a test file. It should not be executed.")
+}

--- a/pkg/analysis/passes/virusscan/testdata/valid/main.go
+++ b/pkg/analysis/passes/virusscan/testdata/valid/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	panic("This is a test file. It should not be executed.")
+}

--- a/pkg/analysis/passes/virusscan/virusscan.go
+++ b/pkg/analysis/passes/virusscan/virusscan.go
@@ -53,6 +53,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
+	// scan the archive
 	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
 
 	if !ok {
@@ -70,9 +71,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// scan the source code
 	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
 	if !ok {
-		// no source code found so we can't check the manifest
+		// no source code found so we can't scan
 		return nil, nil
 	}
+
+	logme.DebugFln("Will run clamav on %s", archiveDir)
 
 	err = runClamavScan(clamavBin, sourceCodeDir, "source code", pass)
 	if err != nil {

--- a/pkg/analysis/passes/virusscan/virusscan.go
+++ b/pkg/analysis/passes/virusscan/virusscan.go
@@ -1,0 +1,191 @@
+package virusscan
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"github.com/grafana/plugin-validator/pkg/logme"
+)
+
+var (
+	virusScanFailed = &analysis.Rule{
+		Name:     "virus-scan-failed",
+		Severity: analysis.Error,
+	}
+)
+
+type ClamAvScanSummary struct {
+	ScannedDirs   int
+	ScannedFiles  int
+	InfectedFiles int
+	KnownViruses  string
+	EngineVersion string
+	DataScanned   string
+	DataRead      string
+	ScanTime      string
+	StartDate     string
+	EndDate       string
+	FoundFiles    []string
+}
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "virusscan",
+	Requires: []*analysis.Analyzer{archive.Analyzer, sourcecode.Analyzer},
+	Run:      run,
+	Rules: []*analysis.Rule{
+		virusScanFailed,
+	},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+
+	// check if clamav is installed
+	clamavBin, err := exec.LookPath("clamscan")
+
+	if err != nil {
+		logme.Debugln("clamav not installed, skipping virus scan")
+		return nil, nil
+	}
+
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+
+	if !ok {
+		return nil, nil
+	}
+
+	logme.DebugFln("Will run clamav on %s", archiveDir)
+
+	err = runClamavScan(clamavBin, archiveDir, "archive", pass)
+	if err != nil {
+		logme.Debugln("clamav failed, skipping virus scan", err)
+		return nil, nil
+	}
+
+	// scan the source code
+	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
+	if !ok {
+		// no source code found so we can't check the manifest
+		return nil, nil
+	}
+
+	err = runClamavScan(clamavBin, sourceCodeDir, "source code", pass)
+	if err != nil {
+		logme.Debugln("clamav failed, skipping virus scan", err)
+		return nil, nil
+	}
+
+	return nil, nil
+}
+
+func runClamavScan(clamavBin string, path string, entityName string, pass *analysis.Pass) error {
+	clamavCommand := exec.Command(clamavBin, "-r", path)
+	clamavOutput, err := clamavCommand.CombinedOutput()
+
+	// clamav exits 1 if it finds issues. Only failing if the output is empty
+	if err != nil && len(clamavOutput) == 0 {
+		logme.Debugln("clamav failed, skipping virus scan", err)
+		return nil
+	}
+
+	scanSummary, err := parseClamAv(string(clamavOutput))
+	if err != nil {
+		logme.Debugln("error parsing clamav output, skipping virus scan", err)
+		return nil
+	}
+
+	if scanSummary.InfectedFiles > 0 {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			virusScanFailed,
+			fmt.Sprintf(
+				"ClamAV found %d infected file(s) inside your %s",
+				scanSummary.InfectedFiles, entityName,
+			),
+			fmt.Sprintf("Files found by ClamAV: %s", strings.Join(scanSummary.FoundFiles, ", ")),
+		)
+	}
+	return nil
+}
+
+func parseClamAv(output string) (ClamAvScanSummary, error) {
+	scanSummary := ClamAvScanSummary{}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	summarySection := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" {
+			continue
+		}
+
+		if strings.Contains(line, "SCAN SUMMARY") {
+			summarySection = true
+			continue
+		}
+
+		if summarySection {
+			keyValue := strings.SplitN(line, ":", 2)
+			if len(keyValue) != 2 {
+				continue
+			}
+			key := strings.TrimSpace(keyValue[0])
+			value := strings.TrimSpace(keyValue[1])
+
+			switch key {
+			case "Scanned directories":
+				var err error
+				scanSummary.ScannedDirs, err = strconv.Atoi(value)
+				if err != nil {
+					return scanSummary, fmt.Errorf("error parsing Scanned directories: %w", err)
+				}
+			case "Scanned files":
+				var err error
+				scanSummary.ScannedFiles, err = strconv.Atoi(value)
+				if err != nil {
+					return scanSummary, fmt.Errorf("error parsing Scanned files: %w", err)
+				}
+			case "Infected files":
+				var err error
+				scanSummary.InfectedFiles, err = strconv.Atoi(value)
+				if err != nil {
+					return scanSummary, fmt.Errorf("error parsing Infected files: %w", err)
+				}
+			case "Known viruses":
+				scanSummary.KnownViruses = value
+			case "Engine version":
+				scanSummary.EngineVersion = value
+			case "Data scanned":
+				scanSummary.DataScanned = value
+			case "Data read":
+				scanSummary.DataRead = value
+			case "Time":
+				scanSummary.ScanTime = value
+			case "Start Date":
+				scanSummary.StartDate = value
+			case "End Date":
+				scanSummary.EndDate = value
+			}
+		} else {
+			if strings.Contains(line, "FOUND") {
+				fileStatus := strings.SplitN(line, ":", 2)
+				if len(fileStatus) == 2 && strings.Contains(fileStatus[1], "FOUND") {
+					scanSummary.FoundFiles = append(scanSummary.FoundFiles, strings.TrimSpace(fileStatus[0]))
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return scanSummary, fmt.Errorf("error scanning input: %w", err)
+	}
+
+	return scanSummary, nil
+}

--- a/pkg/analysis/passes/virusscan/virusscan_test.go
+++ b/pkg/analysis/passes/virusscan/virusscan_test.go
@@ -2,6 +2,7 @@ package virusscan
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -12,7 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func isClamAvInstalled() bool {
+	clamavBin, err := exec.LookPath("clamscan")
+	if err != nil {
+		return false
+	}
+	return clamavBin != ""
+}
 func TestValidArchiveAndSource(t *testing.T) {
+
+	if !isClamAvInstalled() {
+		t.Skip("clamav not installed, skipping test")
+		return
+	}
+
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
@@ -29,6 +43,11 @@ func TestValidArchiveAndSource(t *testing.T) {
 }
 
 func TestInvalidArchive(t *testing.T) {
+	if !isClamAvInstalled() {
+		t.Skip("clamav not installed, skipping test")
+		return
+	}
+
 	var interceptor testpassinterceptor.TestPassInterceptor
 
 	var invalidLocation = filepath.Join("testdata", "invalid")
@@ -60,6 +79,11 @@ func TestInvalidArchive(t *testing.T) {
 }
 
 func TestInvalidSource(t *testing.T) {
+	if !isClamAvInstalled() {
+		t.Skip("clamav not installed, skipping test")
+		return
+	}
+
 	var interceptor testpassinterceptor.TestPassInterceptor
 
 	var invalidLocation = filepath.Join("testdata", "invalid")

--- a/pkg/analysis/passes/virusscan/virusscan_test.go
+++ b/pkg/analysis/passes/virusscan/virusscan_test.go
@@ -1,0 +1,109 @@
+package virusscan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidArchiveAndSource(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer:    filepath.Join("testdata", "valid"),
+			sourcecode.Analyzer: filepath.Join("testdata", "valid"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestInvalidArchive(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+
+	var invalidLocation = filepath.Join("testdata", "invalid")
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: invalidLocation,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	cleanup, err := writeTestEicarFile(invalidLocation)
+	require.NoError(t, err)
+	defer cleanup()
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"ClamAV found 1 infected file(s) inside your archive",
+	)
+	require.Contains(t, interceptor.Diagnostics[0].Detail, "EICAR-test-file")
+	require.Equal(t, interceptor.Diagnostics[0].Severity, analysis.Error)
+
+}
+
+func TestInvalidSource(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+
+	var invalidLocation = filepath.Join("testdata", "invalid")
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer:    filepath.Join("testdata", "valid"),
+			sourcecode.Analyzer: invalidLocation,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	cleanup, err := writeTestEicarFile(invalidLocation)
+	require.NoError(t, err)
+	defer cleanup()
+
+	_, err = Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"ClamAV found 1 infected file(s) inside your source code",
+	)
+	require.Contains(t, interceptor.Diagnostics[0].Detail, "EICAR-test-file")
+	require.Equal(t, interceptor.Diagnostics[0].Severity, analysis.Error)
+
+}
+
+// we don't want to store malicious files (even if test ones)
+// in our repository so we are building an EICAR test file manually
+// nor we want this file to be flagged as virus
+func writeTestEicarFile(location string) (func(), error) {
+	content := "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR"
+	content = content + "-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"
+	file, err := os.Create(filepath.Join(location, "EICAR-test-file"))
+	if err != nil {
+		return nil, err
+	}
+	_, err = file.WriteString(content)
+	if err != nil {
+		return nil, err
+	}
+	return func() { os.Remove(filepath.Join(location, "EICAR-test-file")) }, nil
+}


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-validator/issues/216

Adds a validator to use [ClamAV](https://www.clamav.net/) to validate plugin archives and source code.

This validation only runs if clamav is present in the system via the standalone `clamscan` command.

This PR also adds an installation of clamav to the docker image and it includes a db update via freshclam.
