### PR TITLE
License validation: Detect generic license text

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -288,7 +288,9 @@ func (Run) V2Local(ctx context.Context, path string, sourceCodePath string) erro
 	}
 	command = append(command, path)
 
-	return sh.RunV(command[0], command[1:]...)
+	return sh.RunWithV(map[string]string{
+		"SKIP_CLAMAV": "1",
+	}, command[0], command[1:]...)
 }
 
 func (Run) SourceDiffLocal(ctx context.Context, archive string, source string) error {

--- a/pkg/analysis/passes/license/license.go
+++ b/pkg/analysis/passes/license/license.go
@@ -4,22 +4,29 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/go-enry/go-license-detector/v4/licensedb"
 	"github.com/go-enry/go-license-detector/v4/licensedb/filer"
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/logme"
 )
 
 var (
-	licenseNotProvided = &analysis.Rule{Name: "license-not-provided", Severity: analysis.Error}
+	licenseNotProvided     = &analysis.Rule{Name: "license-not-provided", Severity: analysis.Error}
+	licenseNotValid        = &analysis.Rule{Name: "license-not-valid", Severity: analysis.Error}
+	licenseWithGenericText = &analysis.Rule{
+		Name:     "license-with-generic-text",
+		Severity: analysis.Warning,
+	}
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "license",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
-	Rules:    []*analysis.Rule{licenseNotProvided},
+	Rules:    []*analysis.Rule{licenseNotProvided, licenseNotValid, licenseWithGenericText},
 }
 
 // note: these follow the SPDX license list: https://spdx.org/licenses/
@@ -46,21 +53,36 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	licenseFilePath := filepath.Join(archiveDir, "LICENSE")
 	licenseFile, err := os.Stat(licenseFilePath)
 	if err != nil || licenseFile.IsDir() {
-		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "LICENSE file not found", "Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			licenseNotProvided,
+			"LICENSE file not found",
+			"Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.",
+		)
 		return nil, nil
 	}
 
 	// validate that the LICENSE file is exists (filer lib method)
 	filer, err := filer.FromDirectory(archiveDir)
 	if err != nil {
-		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "LICENSE file not found", "Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			licenseNotProvided,
+			"LICENSE file not found",
+			"Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.",
+		)
 		return nil, nil
 	}
 
 	// validate that the LICENSE file is parseable (go-license-detector lib method)
 	licenses, err := licensedb.Detect(filer)
 	if err != nil {
-		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "LICENSE file could not be parsed.", "Could not parse the license file inside the plugin archive. Please make sure to include a valid license in your LICENSE file in your archive.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			licenseNotProvided,
+			"LICENSE file could not be parsed.",
+			"Could not parse the license file inside the plugin archive. Please make sure to include a valid license in your LICENSE file in your archive.",
+		)
 		return nil, nil
 	}
 
@@ -73,10 +95,32 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if !foundLicense {
-		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "Valid license not found", "The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			licenseNotValid,
+			"Valid license not found",
+			"The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.",
+		)
 	} else if licenseNotProvided.ReportAll {
 		licenseNotProvided.Severity = analysis.OK
 		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "License found", "Found a valid license file inside the plugin archive.")
+	}
+
+	licenseContent, err := os.ReadFile(licenseFilePath)
+	if err != nil {
+		logme.Debugln("Could not read LICENSE file", err)
+		return nil, nil
+	}
+
+	licenseContentStr := string(licenseContent)
+	if strings.Contains(licenseContentStr, "{name of copyright owner}") ||
+		strings.Contains(licenseContentStr, "{yyyy}") {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			licenseWithGenericText,
+			"License file contains generic text",
+			"Your current license file contains generic text from the license template. Please make sure to replace {name of copyright owner} and {yyyy} with the correct values in your LICENSE file.",
+		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/license/license_test.go
+++ b/pkg/analysis/passes/license/license_test.go
@@ -57,7 +57,11 @@ func TestNoLicenseFound(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "LICENSE file not found")
-	require.Equal(t, interceptor.Diagnostics[0].Detail, "Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Detail,
+		"Could not find a license file inside the plugin archive. Please make sure to include a LICENSE file in your archive.",
+	)
 }
 
 func TestValidMitLicense(t *testing.T) {
@@ -107,5 +111,31 @@ func TestInvalidUnilicenseLicense(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
 	require.Equal(t, interceptor.Diagnostics[0].Title, "Valid license not found")
-	require.Equal(t, interceptor.Diagnostics[0].Detail, "The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Detail,
+		"The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.",
+	)
+}
+
+func TestInvalidGenericLicense(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			archive.Analyzer: filepath.Join("testdata", "generic-text"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "License file contains generic text", interceptor.Diagnostics[0].Title)
+	require.Equal(
+		t,
+		"Your current license file contains generic text from the license template. Please make sure to replace {name of copyright owner} and {yyyy} with the correct values in your LICENSE file.",
+		interceptor.Diagnostics[0].Detail,
+	)
 }

--- a/pkg/analysis/passes/license/testdata/generic-text/LICENSE
+++ b/pkg/analysis/passes/license/testdata/generic-text/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 Grafana Labs
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+

--- a/pkg/analysis/passes/virusscan/virusscan.go
+++ b/pkg/analysis/passes/virusscan/virusscan.go
@@ -3,6 +3,7 @@ package virusscan
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -44,6 +45,12 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
+
+	skip := os.Getenv("SKIP_CLAMAV")
+	if skip != "" {
+		logme.Debugln("Skipping virus scan")
+		return nil, nil
+	}
 
 	// check if clamav is installed
 	clamavBin, err := exec.LookPath("clamscan")


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-validator/issues/230

Validates that plugins with a license have correctly populated the copyright year and copyright holder from the generic template text
