### PR TITLE
Code rules: Do not allow console.log in the source code

### DIFF
--- a/pkg/analysis/passes/coderules/coderules_test.go
+++ b/pkg/analysis/passes/coderules/coderules_test.go
@@ -144,4 +144,9 @@ func TestJSConsoleLog(t *testing.T) {
 		interceptor.Diagnostics[0].Detail,
 		"Code rule violation found in testdata/console-log/index.ts at line 2",
 	)
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Severity,
+		analysis.Warning,
+	)
 }

--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -110,3 +110,13 @@ rules:
     message: It is not permitted to use the syscall module. Using syscall.$F is not permitted
     languages: [go]
     severity: ERROR
+
+  - id: detect-console-logs
+    pattern-either:
+      - pattern: console.log(...)
+      - pattern: console.info(...)
+      - pattern: console.table(...)
+      - pattern: console.error(...)
+    message: "Console logging detected. Plugins should not log to the console."
+    languages: [javascript, typescript]
+    severity: WARNING

--- a/pkg/analysis/passes/coderules/testdata/console-log/index.ts
+++ b/pkg/analysis/passes/coderules/testdata/console-log/index.ts
@@ -1,0 +1,3 @@
+function test() {
+  console.log("test");
+}


### PR DESCRIPTION
Adds a semgrep rule to not allow using the console inside the plugin
