### PR TITLE
Trackingscripts: Check for urls

### DIFF
--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -54,15 +54,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 						),
 					)
 					hasTrackingScripts = true
-					break
 				}
 			}
-			if hasTrackingScripts {
-				break
-			}
-		}
-		if hasTrackingScripts {
-			break
 		}
 	}
 

--- a/pkg/analysis/passes/trackingscripts/trackingscripts.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts.go
@@ -1,9 +1,9 @@
 package trackingscripts
 
 import (
-	"bytes"
 	_ "embed"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -35,20 +35,46 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	hasTrackingScripts := false
 
+	urlRegex := regexp.MustCompile(`https?://[^\s]+`)
 	for _, content := range moduleJsMap {
-		for _, url := range servers {
-			if len(url) > 0 && bytes.Contains(content, []byte(url)) {
-				pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: should not include tracking scripts", fmt.Sprintf("Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: %s", url))
-				hasTrackingScripts = true
+		// get all urls in the file
+		matches := urlRegex.FindAll(content, -1)
+		for _, match := range matches {
+			url := string(match)
+			// check if the url is in the servers blocklist
+			for _, server := range servers {
+				if strings.Contains(url, server) {
+					pass.ReportResult(
+						pass.AnalyzerName,
+						trackingScripts,
+						"module.js: should not include tracking scripts",
+						fmt.Sprintf(
+							"Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: %s",
+							url,
+						),
+					)
+					hasTrackingScripts = true
+					break
+				}
+			}
+			if hasTrackingScripts {
 				break
 			}
+		}
+		if hasTrackingScripts {
+			break
 		}
 	}
 
 	if !hasTrackingScripts {
 		if trackingScripts.ReportAll {
 			trackingScripts.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, trackingScripts, "module.js: no tracking scripts detected", "")
+			pass.ReportResult(
+				pass.AnalyzerName,
+				trackingScripts,
+				"module.js: no tracking scripts detected",
+				"",
+			)
 		}
 	}
 

--- a/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
+++ b/pkg/analysis/passes/trackingscripts/trackingscripts_test.go
@@ -44,6 +44,14 @@ func TestTrackingScriptsInvalid(t *testing.T) {
 	_, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "module.js: should not include tracking scripts")
-	require.Equal(t, interceptor.Diagnostics[0].Detail, "Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: google-analytics.com")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"module.js: should not include tracking scripts",
+	)
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Detail,
+		"Tracking scripts are not allowed in Grafana plugins (e.g. google analytics). Please remove any usage of tracking code. Found: https://www.google-analytics.com/analytics.js",
+	)
 }


### PR DESCRIPTION
Improve the logic for the tracking scripts to check only inside urls and not all the code to prevent false positives.