### PR TITLE
Console log: Exclude test files

### DIFF
--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -117,6 +117,12 @@ rules:
       - pattern: console.info(...)
       - pattern: console.table(...)
       - pattern: console.error(...)
+    paths:
+      exclude:
+        - "*.spec.ts"
+        - "*.spec.tsx"
+        - "*.test.ts"
+        - "*.test.tsx"
     message: "Console logging detected. Plugins should not log to the console."
     languages: [javascript, typescript]
     severity: WARNING

--- a/pkg/analysis/passes/coderules/testdata/console-log/bar.spec.tsx
+++ b/pkg/analysis/passes/coderules/testdata/console-log/bar.spec.tsx
@@ -1,0 +1,4 @@
+// This file should be ignored (test file)
+function bar() {
+  console.log("test");
+}

--- a/pkg/analysis/passes/coderules/testdata/console-log/foo.test.ts
+++ b/pkg/analysis/passes/coderules/testdata/console-log/foo.test.ts
@@ -1,0 +1,4 @@
+// This file should be ignored (test file)
+function foo() {
+  console.log("test");
+}


### PR DESCRIPTION
### What changed and why?
We tend to see some false-positives when validating plugins for using `console.log()`, mostly when these are used in files that are not part of the actual production code, but are in tests or any other dev-env related code. E.g.:
```
  * Problem: Console logging detected. Plugins should not log to the console.
    Details: Code rule violation found in /tmp/validator525371450/test/panel.spec.ts at line 6
```

This PR excludes test files from the validation.

### To the reviewer
There is a chance that this is suppressing errors in case a test file is imported to production code. Although the false positives are not ideal, maybe it's better to have those than to miss on a potential console.log() in an imported test file. (I don't think this would really happen to be honest, and even if it does it's not crucial.) 