### PR TITLE
Ignore .js files for console.log check

### DIFF
--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -123,6 +123,7 @@ rules:
         - "*.spec.tsx"
         - "*.test.ts"
         - "*.test.tsx"
+        - "*.js"
     message: "Console logging detected. Plugins should not log to the console."
     languages: [javascript, typescript]
     severity: WARNING

--- a/pkg/analysis/passes/coderules/testdata/console-log/foobar.js
+++ b/pkg/analysis/passes/coderules/testdata/console-log/foobar.js
@@ -1,0 +1,4 @@
+// This file should be ignored (test file)
+function foobar() {
+  console.log("test");
+}


### PR DESCRIPTION
.JS files are usually not production files in the plugin so it doesn't need to be evaluated.

Fixes false positive at https://grafana.zendesk.com/agent/tickets/148284