### PR TITLE
Semgrep: Update console patterns

### DIFF
--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -116,6 +116,18 @@ rules:
       - pattern: console.log(...)
       - pattern: console.info(...)
       - pattern: console.table(...)
+      - pattern: console.debug(...)
+      - pattern: console.clear(...)
+      - pattern: console.count(...)
+      - pattern: console.countReset(...)
+      - pattern: console.dir(...)
+      - pattern: console.dirxml(...)
+      - pattern: console.group(...)
+      - pattern: console.groupEnd(...)
+      - pattern: console.time(...)
+      - pattern: console.timeEnd(...)
+      - pattern: console.timeLog(...)
+      - pattern: console.trace(...)
     paths:
       exclude:
         - "*.spec.ts"

--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -116,7 +116,6 @@ rules:
       - pattern: console.log(...)
       - pattern: console.info(...)
       - pattern: console.table(...)
-      - pattern: console.error(...)
     paths:
       exclude:
         - "*.spec.ts"


### PR DESCRIPTION
**Related Slack discussion:** https://raintank-corp.slack.com/archives/C024NL6AEJH/p1726044254166559

### What changed?
- stops warning on `console.error()` statements in plugins (we think that there can be use cases for logging errors from plugins)
- adds warnings for other console methods, too, e.g. `console.debug()`, `console.trace()`, etc. 