### PR TITLE
Add severity flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Usage plugincheck2:
         If set, the checksum of the plugin archive will be checked against this value. MD5 and SHA256 are supported.
   -analyzer string (optional)
         If set, only an specific analyzer and it's dependencies will run.
+  -severity string (optional)
+        If set, it will override the severity of the analyzer.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage plugincheck2:
   -analyzer string (optional)
         If set, only an specific analyzer and it's dependencies will run.
   -severity string (optional)
-        If set, it will override the severity of the analyzer.
+        If used, it will set the severity of the analyzer (it has the highest priority).
 
 ```
 

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -51,6 +51,11 @@ func main() {
 			"",
 			"Run a specific analyzer",
 		)
+		severity = flag.String(
+			"severity",
+			"",
+			"Set severity of the analyzer",
+		)
 	)
 
 	flag.Parse()
@@ -62,6 +67,7 @@ func main() {
 	logme.Debugln("archive file: ", flag.Arg(0))
 	logme.Debugln("checksum: ", *checksum)
 	logme.Debugln("analyzer: ", *analyzer)
+	logme.Debugln("severity: ", *severity)
 
 	cfg, err := readConfigFile(*configFlag)
 	if err != nil {
@@ -131,6 +137,7 @@ func main() {
 			ArchiveCalculatedSHA1: fmt.Sprintf("%x", sha1hash),
 		},
 		cfg,
+		analysis.Severity(*severity),
 	)
 	if err != nil {
 		logme.Errorln(fmt.Errorf("check failed: %w", err))

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -51,10 +51,10 @@ func main() {
 			"",
 			"Run a specific analyzer",
 		)
-		severity = flag.String(
-			"severity",
+		analyzerSeverity = flag.String(
+			"analyzerSeverity",
 			"",
-			"Set severity of the analyzer",
+			"Set severity of the analyzer. Only works in combination with -analyzer",
 		)
 	)
 
@@ -67,7 +67,7 @@ func main() {
 	logme.Debugln("archive file: ", flag.Arg(0))
 	logme.Debugln("checksum: ", *checksum)
 	logme.Debugln("analyzer: ", *analyzer)
-	logme.Debugln("severity: ", *severity)
+	logme.Debugln("analyzerSeverity: ", *analyzerSeverity)
 
 	cfg, err := readConfigFile(*configFlag)
 	if err != nil {
@@ -117,13 +117,18 @@ func main() {
 	}
 
 	analyzers := passes.Analyzers
+	severity := analysis.Severity("")
 
 	if *analyzer != "" {
 		for _, a := range analyzers {
 			if a.Name == *analyzer {
 				analyzers = []*analysis.Analyzer{a}
+
 				break
 			}
+		}
+		if *analyzerSeverity != "" {
+			severity = analysis.Severity(*analyzerSeverity)
 		}
 	}
 
@@ -137,7 +142,7 @@ func main() {
 			ArchiveCalculatedSHA1: fmt.Sprintf("%x", sha1hash),
 		},
 		cfg,
-		analysis.Severity(*severity),
+		severity,
 	)
 	if err != nil {
 		logme.Errorln(fmt.Errorf("check failed: %w", err))

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -236,7 +236,7 @@ func TestIntegration(t *testing.T) {
 		{
 			name:      "severity-flag-test",
 			file:      "invalid2.zip",
-			extraArgs: "-analyzer=metadatavalid -severity=warning",
+			extraArgs: "-analyzer=metadatavalid -analyzerSeverity=warning",
 			jsonReport: JsonReport{
 				Id:      "invalid-panel",
 				Version: "1.0.0",
@@ -247,6 +247,25 @@ func TestIntegration(t *testing.T) {
 							Title:    "plugin.json: dependencies: grafanaDependency is required",
 							Detail:   "The plugin.json file is not following the schema. Please refer to the documentation for more information. https://grafana.com/docs/grafana/latest/developers/plugins/metadata/",
 							Name:     "invalid-metadata",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "severity-flag-no-changes-when-analyzer-not-set",
+			file:      "grafana-clock-panel-2.1.5.any.zip",
+			extraArgs: "-analyzerSeverity=ok",
+			jsonReport: JsonReport{
+				Id:      "grafana-clock-panel",
+				Version: "2.1.5",
+				PluginValidator: map[string][]Issue{
+					"jargon": {
+						{
+							Severity: "warning",
+							Title:    "README.md contains developer jargon: (yarn)",
+							Detail:   "Move any developer and contributor documentation to a separate file and link to it from the README.md. For example, CONTRIBUTING.md, DEVELOPMENT.md, etc.",
+							Name:     "developer-jargon",
 						},
 					},
 				},

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -29,6 +29,7 @@ type JsonReport struct {
 }
 
 type tc struct {
+	name       string
 	file       string
 	extraArgs  string
 	jsonReport JsonReport
@@ -214,6 +215,7 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
+			name:      "analyzer-flag-test",
 			file:      "invalid2.zip",
 			extraArgs: "-analyzer=metadatavalid",
 			jsonReport: JsonReport{
@@ -231,18 +233,41 @@ func TestIntegration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "severity-flag-test",
+			file:      "invalid2.zip",
+			extraArgs: "-analyzer=metadatavalid -severity=warning",
+			jsonReport: JsonReport{
+				Id:      "invalid-panel",
+				Version: "1.0.0",
+				PluginValidator: map[string][]Issue{
+					"metadatavalid": {
+						{
+							Severity: "warning",
+							Title:    "plugin.json: dependencies: grafanaDependency is required",
+							Detail:   "The plugin.json file is not following the schema. Please refer to the documentation for more information. https://grafana.com/docs/grafana/latest/developers/plugins/metadata/",
+							Name:     "invalid-metadata",
+						},
+					},
+				},
+			},
+		},
 	}
 	configFile := filepath.Join(basePath, "integration-tests.yaml")
 
 	t.Logf("Running integration tests. Total: %d\n", len(tcs))
 	for _, tc := range tcs {
 		currentFile := tc.file
-		t.Run(currentFile, func(t *testing.T) {
+		tcName := tc.name
+		if tcName == "" {
+			tcName = currentFile
+		}
+		t.Run(tcName, func(t *testing.T) {
 			file := currentFile
 			// Allows the test case to run in parallel with other ones
 			t.Parallel()
 
-			t.Logf("Running %s", file)
+			t.Logf("Running %s", tcName)
 
 			extraArgs := ""
 			if tc.extraArgs != "" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,6 +38,7 @@ func Check(
 	analyzers []*analysis.Analyzer,
 	params analysis.CheckParams,
 	cfg Config,
+	severity analysis.Severity,
 ) (map[string][]analysis.Diagnostic, error) {
 	pluginId, err := utils.GetPluginId(params.ArchiveDir)
 	if err != nil {
@@ -46,7 +47,7 @@ func Check(
 		logme.Debugln("Error getting plugin id")
 	}
 
-	initAnalyzers(analyzers, &cfg, pluginId)
+	initAnalyzers(analyzers, &cfg, pluginId, severity)
 	diagnostics := make(map[string][]analysis.Diagnostic)
 
 	pass := &analysis.Pass{
@@ -98,7 +99,7 @@ func Check(
 	return diagnostics, nil
 }
 
-func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string) {
+func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string, severity analysis.Severity) {
 	for _, currentAnalyzer := range analyzers {
 		// Inherit global config file
 		analyzerEnabled := cfg.Global.Enabled
@@ -144,6 +145,10 @@ func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string)
 				if ruleConfig.Severity != nil {
 					ruleSeverity = *ruleConfig.Severity
 				}
+			}
+
+			if severity != "" {
+				ruleSeverity = severity
 			}
 
 			currentRule.Disabled = !ruleEnabled

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,7 +38,7 @@ func Check(
 	analyzers []*analysis.Analyzer,
 	params analysis.CheckParams,
 	cfg Config,
-	severity analysis.Severity,
+	severityOverwrite analysis.Severity,
 ) (map[string][]analysis.Diagnostic, error) {
 	pluginId, err := utils.GetPluginId(params.ArchiveDir)
 	if err != nil {
@@ -47,7 +47,7 @@ func Check(
 		logme.Debugln("Error getting plugin id")
 	}
 
-	initAnalyzers(analyzers, &cfg, pluginId, severity)
+	initAnalyzers(analyzers, &cfg, pluginId, severityOverwrite)
 	diagnostics := make(map[string][]analysis.Diagnostic)
 
 	pass := &analysis.Pass{
@@ -99,7 +99,7 @@ func Check(
 	return diagnostics, nil
 }
 
-func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string, severity analysis.Severity) {
+func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string, severityOverwrite analysis.Severity) {
 	for _, currentAnalyzer := range analyzers {
 		// Inherit global config file
 		analyzerEnabled := cfg.Global.Enabled
@@ -147,8 +147,8 @@ func initAnalyzers(analyzers []*analysis.Analyzer, cfg *Config, pluginId string,
 				}
 			}
 
-			if severity != "" {
-				ruleSeverity = severity
+			if severityOverwrite != "" {
+				ruleSeverity = severityOverwrite
 			}
 
 			currentRule.Disabled = !ruleEnabled

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -67,7 +67,9 @@ func TestRunner(t *testing.T) {
 					SourceCodeDir: "",
 					Checksum:      "",
 				},
-				Config{Global: GlobalConfig{Enabled: true}})
+				Config{Global: GlobalConfig{Enabled: true}},
+				analysis.Severity(""),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -146,6 +148,7 @@ func TestLinearDependencies(t *testing.T) {
 			Checksum:      "",
 		},
 		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
 	)
 
 	if len(res) != 4 {
@@ -188,6 +191,7 @@ func TestSharedParent(t *testing.T) {
 			Checksum:      "",
 		},
 		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
 	)
 
 	if len(res) != 3 {
@@ -230,6 +234,7 @@ func TestCachedRun(t *testing.T) {
 			Checksum:      "",
 		},
 		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
 	)
 
 	if len(res) != 3 {
@@ -263,6 +268,7 @@ func TestDependencyReturnsNil(t *testing.T) {
 			Checksum:      "",
 		},
 		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
 	)
 
 	assert.Len(t, res, 2)


### PR DESCRIPTION
Add `severity` flag to `plugincheck2`.
This flag is used to set the severity of every rule in every analyzer and it has higher priority compared to all possible was set  severity by config and by the code.