### PR TITLE
osvscanner: handle new pnpm format

### DIFF
--- a/pkg/analysis/passes/osvscanner/lockfile/parse-pnpm-lock.go
+++ b/pkg/analysis/passes/osvscanner/lockfile/parse-pnpm-lock.go
@@ -80,13 +80,16 @@ func extractPnpmPackageNameAndVersion(dependencyPath string) (string, string) {
 	var name string
 
 	parts = parts[1:]
-
-	if strings.HasPrefix(parts[0], "@") {
-		name = strings.Join(parts[:2], "/")
-		parts = parts[2:]
+	if len(parts) > 0 {
+		if strings.HasPrefix(parts[0], "@") {
+			name = strings.Join(parts[:2], "/")
+			parts = parts[2:]
+		} else {
+			name = parts[0]
+			parts = parts[1:]
+		}
 	} else {
-		name = parts[0]
-		parts = parts[1:]
+		return "", ""
 	}
 
 	version := ""


### PR DESCRIPTION
the pnpm parser can fail when the dependency list is empty, this checks the length and returns a value vs dereferencing an empty array
