### PR TITLE
License detect timeout

### DIFF
--- a/pkg/analysis/passes/license/license.go
+++ b/pkg/analysis/passes/license/license.go
@@ -5,8 +5,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-enry/go-license-detector/v4/licensedb"
+	"github.com/go-enry/go-license-detector/v4/licensedb/api"
 	"github.com/go-enry/go-license-detector/v4/licensedb/filer"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -79,53 +81,64 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	// validate that the LICENSE file is parseable (go-license-detector lib method)
-	licenses, err := licensedb.Detect(f)
-	if err != nil {
+	ch := make(chan map[string]api.Match, 1)
+	defer close(ch)
+	go func() {
+		// validate that the LICENSE file is parseable (go-license-detector lib method)
+		licenses, err := licensedb.Detect(f)
+		if err != nil {
+			ch <- nil
+			return
+		}
+		ch <- licenses
+	}()
+
+	select {
+	case licenses := <-ch:
+		var foundLicense = false
+		for licenseName, licenseData := range licenses {
+			if licenseData.Confidence >= minRequiredConfidenceLevel && isValidLicense(licenseName) {
+				foundLicense = true
+				break
+			}
+		}
+
+		if !foundLicense {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				licenseNotValid,
+				"Valid license not found",
+				"The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.",
+			)
+		} else if licenseNotProvided.ReportAll {
+			licenseNotProvided.Severity = analysis.OK
+			pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "License found", "Found a valid license file inside the plugin archive.")
+		}
+
+		licenseContent, err := os.ReadFile(licenseFilePath)
+		if err != nil {
+			logme.Debugln("Could not read LICENSE file", err)
+			return nil, nil
+		}
+
+		licenseContentStr := string(licenseContent)
+		if strings.Contains(licenseContentStr, "{name of copyright owner}") ||
+			strings.Contains(licenseContentStr, "{yyyy}") {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				licenseWithGenericText,
+				"License file contains generic text",
+				"Your current license file contains generic text from the license template. Please make sure to replace {name of copyright owner} and {yyyy} with the correct values in your LICENSE file.",
+			)
+		}
+	case <-time.After(time.Second * 30):
 		pass.ReportResult(
 			pass.AnalyzerName,
 			licenseNotProvided,
-			"LICENSE file could not be parsed.",
-			"Could not parse the license file inside the plugin archive. Please make sure to include a valid license in your LICENSE file in your archive.",
+			"LICENSE file detection timeout.",
+			"Could not detect the license file inside the plugin archive within 30s. Please make sure to include a valid license in your LICENSE file in your archive.",
 		)
 		return nil, nil
-	}
-
-	var foundLicense = false
-	for licenseName, licenseData := range licenses {
-		if licenseData.Confidence >= minRequiredConfidenceLevel && isValidLicense(licenseName) {
-			foundLicense = true
-			break
-		}
-	}
-
-	if !foundLicense {
-		pass.ReportResult(
-			pass.AnalyzerName,
-			licenseNotValid,
-			"Valid license not found",
-			"The provided license is not compatible with Grafana plugins. Please refer to https://grafana.com/licensing/ for more information.",
-		)
-	} else if licenseNotProvided.ReportAll {
-		licenseNotProvided.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, licenseNotProvided, "License found", "Found a valid license file inside the plugin archive.")
-	}
-
-	licenseContent, err := os.ReadFile(licenseFilePath)
-	if err != nil {
-		logme.Debugln("Could not read LICENSE file", err)
-		return nil, nil
-	}
-
-	licenseContentStr := string(licenseContent)
-	if strings.Contains(licenseContentStr, "{name of copyright owner}") ||
-		strings.Contains(licenseContentStr, "{yyyy}") {
-		pass.ReportResult(
-			pass.AnalyzerName,
-			licenseWithGenericText,
-			"License file contains generic text",
-			"Your current license file contains generic text from the license template. Please make sure to replace {name of copyright owner} and {yyyy} with the correct values in your LICENSE file.",
-		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/license/license.go
+++ b/pkg/analysis/passes/license/license.go
@@ -136,7 +136,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pass.ReportResult(
 			pass.AnalyzerName,
 			licenseDetectionTimeout,
-			"LICENSE file detection timeout.",
+			"License file detection timeout.",
 			"Could not detect the license file inside the plugin archive within 30s. Please make sure to include a valid license in your LICENSE file in your archive.",
 		)
 		return nil, nil

--- a/pkg/analysis/passes/license/license.go
+++ b/pkg/analysis/passes/license/license.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	licenseNotProvided     = &analysis.Rule{Name: "license-not-provided", Severity: analysis.Error}
-	licenseNotValid        = &analysis.Rule{Name: "license-not-valid", Severity: analysis.Error}
-	licenseWithGenericText = &analysis.Rule{
+	licenseNotProvided      = &analysis.Rule{Name: "license-not-provided", Severity: analysis.Error}
+	licenseNotValid         = &analysis.Rule{Name: "license-not-valid", Severity: analysis.Error}
+	licenseDetectionTimeout = &analysis.Rule{Name: "license-detection-timeout", Severity: analysis.Error}
+	licenseWithGenericText  = &analysis.Rule{
 		Name:     "license-with-generic-text",
 		Severity: analysis.Warning,
 	}
@@ -134,7 +135,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	case <-time.After(time.Second * 30):
 		pass.ReportResult(
 			pass.AnalyzerName,
-			licenseNotProvided,
+			licenseDetectionTimeout,
 			"LICENSE file detection timeout.",
 			"Could not detect the license file inside the plugin archive within 30s. Please make sure to include a valid license in your LICENSE file in your archive.",
 		)


### PR DESCRIPTION
A [plugin submission](https://grafana.zendesk.com/agent/tickets/164815) is causing the license detection to hang, therefore we should wrap the call in a timeout. 

See [here](https://github.com/grafana/community-pipeline/actions/runs/12256831162) for failed run.