### PR TITLE
LLM Validator: Improve questions and prompt generation

### DIFF
--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -51,7 +51,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	logme.Debugln("Starting to run Gemini Validations. This might take a while...")
 
-	llmClient, err := llmvalidate.New(context.Background(), geminiKey, "gemini-1.5-flash-latest")
+	llmClient, err := llmvalidate.New(context.Background(), geminiKey, "gemini-2.0-flash")
 
 	if err != nil {
 		logme.DebugFln("Error initializing llm client: %v", err)

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -40,7 +40,7 @@ var questions = []llmvalidate.LLMQuestion{
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
+		Question:       "Only for go/golang code: Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
 		ExpectedAnswer: false,
 	},
 	{

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -86,18 +86,8 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	retry := 3
 	var answers []llmvalidate.LLMAnswer
-
-	for range retry {
-		answers, err = llmClient.AskLLMAboutCode(sourceCodeDir, questions, []string{"src", "pkg"})
-		if err != nil {
-			logme.DebugFln("Error getting answers from Gemini LLM: %v", err)
-		} else {
-			break
-		}
-	}
-
+	answers, err = llmClient.AskLLMAboutCode(sourceCodeDir, questions, []string{"src", "pkg"})
 	if err != nil {
 		logme.DebugFln("Error getting answers from Gemini LLM: %v", err)
 		return nil, nil

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -32,36 +32,40 @@ var Analyzer = &analysis.Analyzer{
 
 var questions = []llmvalidate.LLMQuestion{
 	{
-		Question:       "Only for go/golang code: Does this code manipulate the file system? (explicit manipulation of the file system, other system calls are allowed). Provide a code snippet if so.",
+		Question:       "Only for go/golang code: Does this code directly read from or write to the file system? (Look for uses of os.Open, os.Create, ioutil.ReadFile, ioutil.WriteFile, etc.). Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code allow the execution or arbitrary code from user input? (browser environment). Provide a code snippet if so",
+		Question:       "Does this code execute user input as code in a browser environment? (Look for eval(), new Function(), document.write() with unescaped content, innerHTML with script tags, etc.). Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Only for go/golang code: Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
+		Question:       "Only for go/golang code: Does this code execute user input as commands or code in the backend? (Look for exec.Command, syscall.Exec, template.Execute with user data, etc.). Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code introduces analytics or tracking not part of Grafana APIs? (reportInteraction from @grafana/runtime is allowed). Provide a code snippet if so.",
+		Question:       "Does this code introduce third-party analytics or tracking features? (Grafana's reportInteraction from @grafana/runtime is allowed, but external services like Google Analytics, Mixpanel, etc. are not). Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code modifies global variables in the window object? (browser environment). Provide a code snippet if so.",
+		Question:       "Does this code modify or create properties on the global window object? (Look for direct assignments like window.customVariable = x, window.functionName = function(){}, or adding undeclared variables in global scope). Exclude standard browser API usage. Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code introduce global css? (emotion css is allowed). Provide a code snippet if so.",
+		Question:       "Does this code introduce global CSS not scoped to components? (Emotion CSS and CSS modules are allowed, but look for direct style tags, global class definitions, or modification of document.styleSheets). Provide the specific code snippet if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Does this code injects third party scripts outside of its own source? (browser environment). Provide a code snippet if so.",
+		Question:       "Does this code dynamically inject external third-party scripts? (Look for createElement('script'), setting src attributes to external domains, document.write with script tags, or dynamic import() from external sources). Provide the specific code snippet with the external URL if found.",
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Only for go/golang code: Does this code open correctly closes open resources? (e.g. files, network connections). Provide a code snippet if so.",
+		Question:       "Only for go/golang code: Are all opened resources properly closed? (Check that files, network connections, etc. are closed with defer, in finally blocks, or using 'with' statements). Identify any resources that aren't properly closed with a code snippet.",
 		ExpectedAnswer: true,
+	},
+	{
+		Question:       "Does this code use global DOM selectors outside of component lifecycle methods? (Look for direct usage of document.querySelector(), document.getElementById(), document.getElementsByClassName(), etc. that aren't scoped to specific components or that bypass React refs). Component-scoped element access like useRef() or this.elementRef is acceptable. Provide the specific code snippet showing the global access if found.",
+		ExpectedAnswer: false,
 	},
 }
 

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -37,7 +37,7 @@ var questions = []string{
 	"Does this code introduces analytics or tracking not part of Grafana APIs?. Provide a code snippet if so.",
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	var err error
 	// only run if sourcecode.Analyzer succeeded
 	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
@@ -76,8 +76,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	for _, answer := range answers {
-		shortAnswer := strings.TrimSpace(strings.ToLower(answer.ShortAnswer))
-		if shortAnswer != "no" {
+		if answer.ShortAnswer {
 
 			detail := fmt.Sprintf("Question: %s\n. Answer: %s. ", answer.Question, answer.Answer)
 

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -60,7 +60,7 @@ var questions = []llmvalidate.LLMQuestion{
 		ExpectedAnswer: false,
 	},
 	{
-		Question:       "Only for go/golang code: Are all opened resources properly closed? (Check that files, network connections, etc. are closed with defer, in finally blocks, or using 'with' statements). Identify any resources that aren't properly closed with a code snippet.",
+		Question:       "Only for go/golang code: Are all opened resources properly closed? (Check that files, network connections, etc. are closed with defer, in finally blocks, or using 'with' statements). Identify any resources that aren't properly closed with a code snippet. If there is no backend code reply positively",
 		ExpectedAnswer: true,
 	},
 	{

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -30,11 +30,39 @@ var Analyzer = &analysis.Analyzer{
 	},
 }
 
-var questions = []string{
-	"Does this code manipulate the file system? (explicit manipulation of the file system). Provide a code snippet if so.",
-	"Does this code allow the execution or arbitrary code from user input? (browser environment). Provide a code snippet if so",
-	"Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
-	"Does this code introduces analytics or tracking not part of Grafana APIs?. Provide a code snippet if so.",
+var questions = []llmvalidate.LLMQuestion{
+	{
+		Question:       "Only for go/golang code: Does this code manipulate the file system? (explicit manipulation of the file system, other system calls are allowed). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code allow the execution or arbitrary code from user input? (browser environment). Provide a code snippet if so",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code introduces analytics or tracking not part of Grafana APIs? (reportInteraction from @grafana/runtime is allowed). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code modifies global variables in the window object? (browser environment). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code introduce global css? (emotion css is allowed). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Does this code injects third party scripts outside of its own source? (browser environment). Provide a code snippet if so.",
+		ExpectedAnswer: false,
+	},
+	{
+		Question:       "Only for go/golang code: Does this code open correctly closes open resources? (e.g. files, network connections). Provide a code snippet if so.",
+		ExpectedAnswer: true,
+	},
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -76,7 +104,7 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 
 	for _, answer := range answers {
-		if answer.ShortAnswer {
+		if answer.ShortAnswer != answer.ExpectedShortAnswer {
 
 			detail := fmt.Sprintf("Question: %s\n. Answer: %s. ", answer.Question, answer.Answer)
 

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -32,8 +32,8 @@ var Analyzer = &analysis.Analyzer{
 
 var questions = []string{
 	"Does this code manipulate the file system? (explicit manipulation of the file system). Provide a code snippet if so.",
-	"Does this code allow the execution or arbitrary javascript code from user input?. Provide a code snippet if so",
-	"Does this code allow the execution or arbitrary code in go from user input?. Provide a code snippet if so.",
+	"Does this code allow the execution or arbitrary code from user input? (browser environment). Provide a code snippet if so",
+	"Does this code allow the execution or arbitrary code from user input in the backend? (not browser environment, analyze back-end code). Provide a code snippet if so.",
 	"Does this code introduces analytics or tracking not part of Grafana APIs?. Provide a code snippet if so.",
 }
 
@@ -51,7 +51,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 	logme.Debugln("Starting to run Gemini Validations. This might take a while...")
 
-	llmClient, err := llmvalidate.New(context.Background(), geminiKey, "gemini-2.0-flash")
+	llmClient, err := llmvalidate.New(context.Background(), geminiKey, "gemini-2.0-flash-001")
 
 	if err != nil {
 		logme.DebugFln("Error initializing llm client: %v", err)
@@ -61,7 +61,7 @@ func run(pass *analysis.Pass) (any, error) {
 	retry := 3
 	var answers []llmvalidate.LLMAnswer
 
-	for i := 0; i < retry; i++ {
+	for range retry {
 		answers, err = llmClient.AskLLMAboutCode(sourceCodeDir, questions, []string{"src", "pkg"})
 		if err != nil {
 			logme.DebugFln("Error getting answers from Gemini LLM: %v", err)

--- a/pkg/llmvalidate/llmvalidate.go
+++ b/pkg/llmvalidate/llmvalidate.go
@@ -280,8 +280,6 @@ func getTextContentFromModelContentResponse(modelResponse *genai.GenerateContent
 	for _, part := range content.Parts {
 		finalContent += fmt.Sprint(part)
 	}
-	// replace any duplicated new lines with a single new line
-	finalContent = strings.ReplaceAll(finalContent, "\n\n", "\n")
 	return finalContent
 }
 

--- a/pkg/llmvalidate/llmvalidate.go
+++ b/pkg/llmvalidate/llmvalidate.go
@@ -198,7 +198,16 @@ func (c *Client) AskLLMAboutCode(
 	model.SystemInstruction = &genai.Content{
 		Parts: []genai.Part{
 			genai.Text(
-				`You are source code reviewer. You are provided with a source code repository information and files. You will answer questions only based on the context of the files provided. The output muset be a valid JSON object`,
+				`You are source code reviewer. You are provided with a source code repository information and files. You will answer questions only based on the context of the files provided. The output muset be a valid JSON object
+
+				REVIEWER NOTE: When reviewing, exempt code that is explicitly for testing or development purposes. This includes:
+					- Test files (*_test.go, *_spec.ts, etc.)
+					- Scripts dedicated  for development (e.g. test servers, seeding)
+					- Code that is clearly marked as development-only with comments
+					- Local development servers and database setup utilities
+
+				Focus your review on code that will run in production environments as part of a Grafana Plugin
+				`,
 			),
 		},
 	}

--- a/pkg/llmvalidate/llmvalidate.go
+++ b/pkg/llmvalidate/llmvalidate.go
@@ -110,7 +110,7 @@ func New(ctx context.Context, apiKey string, modelName string) (*Client, error) 
 	}
 
 	if modelName == "" {
-		modelName = "gemini-2.0-flash-lite"
+		return nil, fmt.Errorf("Model name is required")
 	}
 	logme.DebugFln("llmvalidate: Using model %s", modelName)
 

--- a/pkg/llmvalidate/llmvalidate.go
+++ b/pkg/llmvalidate/llmvalidate.go
@@ -93,8 +93,9 @@ func New(ctx context.Context, apiKey string, modelName string) (*Client, error) 
 	}
 
 	if modelName == "" {
-		modelName = "gemini-1.5-flash-latest"
+		modelName = "gemini-2.0-flash-lite"
 	}
+	logme.DebugFln("llmvalidate: Using model %s", modelName)
 
 	genaiClient, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))
 	if err != nil {
@@ -190,9 +191,11 @@ Answer the following questions in the context of the code above. be brief in you
 	var answers []LLMAnswer
 	err = json.Unmarshal([]byte(content), &answers)
 	if err != nil {
+		logme.DebugFln("Failed to unmarshal content: %v", content)
 		return nil, fmt.Errorf("failed to unmarshal content: %v", err)
 	}
-	logme.Debugln("Got response from LLM with char length", len(answers))
+	logme.DebugFln("Got answers from LLM: %v", answers)
+	logme.Debugln("Got response from LLM with char length", len(content))
 
 	return answers, nil
 

--- a/pkg/llmvalidate/llmvalidate.go
+++ b/pkg/llmvalidate/llmvalidate.go
@@ -200,6 +200,13 @@ func (c *Client) AskLLMAboutCode(
 		`The files in the repository are: %s `,
 		strings.Join(codePrompt, "\n"),
 	)
+
+	tokenCount, err := model.CountTokens(c.ctx, genai.Text(filesPrompt))
+	if err != nil {
+		logme.DebugFln("Error counting tokens: %v", err)
+	}
+	logme.DebugFln("llmvalidate: Token count for files prompt: %d", tokenCount)
+
 	var answers []LLMAnswer = make([]LLMAnswer, len(questions))
 
 	for _, question := range questions {

--- a/pkg/prettyprint/prettyprint.go
+++ b/pkg/prettyprint/prettyprint.go
@@ -9,3 +9,8 @@ func Print(b any) {
 	s, _ := json.MarshalIndent(b, "", "\t")
 	fmt.Print(string(s))
 }
+
+func SPrint(b any) string {
+	s, _ := json.MarshalIndent(b, "", "\t")
+	return string(s)
+}


### PR DESCRIPTION
### main change
It now asks the model one question at the time instead of all questions at once.

This change allows the model to focus on replying a single question which greatly improves its answers. It also means the validator now consumes more api credits from google when running. 

### Other changes

* Updates the LLM model to use `gemini-2.0-flash-001` (stable gemini flash 2)
* Changes the question structure to have an expected answer instead of always expecting a positive
* Adds structured output to LLM
* Adds more questions for code
* Moves retrial logic to per-question