### PR TITLE
Tests: Disables brokenlinks analyzer in integration tests

### DIFF
--- a/pkg/analysis/passes/brokenlinks/brokenlinks_test.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -29,6 +30,73 @@ func TestNoRelativePaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, interceptor.Diagnostics[0].Title, "README.md: convert relative link to absolute: ./with/relative/path")
+	require.Equal(
+		t,
+		interceptor.Diagnostics[0].Title,
+		"README.md: convert relative link to absolute: ./with/relative/path",
+	)
+}
 
+func TestBrokenLink(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	brokenURL := "https://example.com/broken-link"
+	httpmock.RegisterResponder("GET", brokenURL,
+		httpmock.NewStringResponder(404, "Not Found"))
+
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]any{
+			metadata.Analyzer: []byte(
+				`{"ID": "` + pluginId + `", "info": {"links": [{"url": "` + brokenURL + `"}]}}`,
+			),
+			readme.Analyzer: []byte(`# README`),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, interceptor.Diagnostics)
+
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(
+		t,
+		"plugin.json: possible broken link: https://example.com/broken-link (404 Not Found)",
+		interceptor.Diagnostics[0].Title,
+	)
+	require.Equal(
+		t,
+		"README.md might contain broken links. Check that all links are valid and publicly accessible.",
+		interceptor.Diagnostics[0].Detail,
+	)
+}
+
+func TestValidLink(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	validURL := "https://example.com/valid-link"
+	httpmock.RegisterResponder("GET", validURL,
+		httpmock.NewStringResponder(200, "OK"))
+
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]any{
+			metadata.Analyzer: []byte(
+				`{"ID": "` + pluginId + `", "info": {"links": [{"url": "` + validURL + `"}]}}`,
+			),
+			readme.Analyzer: []byte(`# README [Valid Link](` + validURL + `)`),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+
+	require.Empty(t, interceptor.Diagnostics)
 }

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/jarcoal/httpmock"
 	"github.com/r3labs/diff"
 	"github.com/stretchr/testify/assert"
 
@@ -39,15 +37,6 @@ type tc struct {
 }
 
 func TestIntegration(t *testing.T) {
-	// Set up HTTP mocking
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	// Mock the GitHub URLs that are returning 429 errors
-	httpmock.RegisterResponder("GET", "https://github.com/grafana/clock-panel/blob/master/LICENSE",
-		httpmock.NewStringResponder(http.StatusOK, "Mock license content"))
-	httpmock.RegisterResponder("GET", "https://github.com/grafana/grafana-zabbix/blob/main/LICENSE",
-		httpmock.NewStringResponder(http.StatusOK, "Mock license content"))
 
 	basePath := "./testdata"
 	binary := filepath.Join(

--- a/pkg/cmd/plugincheck2/testdata/integration-tests.yaml
+++ b/pkg/cmd/plugincheck2/testdata/integration-tests.yaml
@@ -6,3 +6,5 @@ global:
 analyzers:
   version:
     enabled: false
+  brokenlinks:
+    enabled: false


### PR DESCRIPTION
The integrations tests had been failing at random (as reported [here](https://github.com/grafana/plugin-validator/pull/334#issuecomment-2883463728)) due to the brokenlinks validator hitting github rate limit 

The existing mocks using `jarcoal/httpmock` were not working because the integration tests spawn the validator process itself and it won't be affected by mocks.

considering the alternative is to create a setup with proxies and mock responses the easier approach is to disable the validator for the integration tests and instead improve its own tests
