### PR TITLE
fix: needs to check all the links

### DIFF
--- a/pkg/analysis/passes/sponsorshiplink/sponsorshiplink.go
+++ b/pkg/analysis/passes/sponsorshiplink/sponsorshiplink.go
@@ -40,13 +40,15 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		pass.ReportResult(pass.AnalyzerName, sponsorshiplink, recommendation, explanation)
 		return nil, nil
 	}
-
+	hasSponsorLink := false
 	for _, link := range data.Info.Links {
 		name := strings.ToLower(link.Name)
-		if !strings.Contains(name, "sponsor") && !strings.Contains(name, "sponsorship") {
-			pass.ReportResult(pass.AnalyzerName, sponsorshiplink, recommendation, explanation)
-			return nil, nil
+		if strings.Contains(name, "sponsor") || strings.Contains(name, "sponsorship") {
+			hasSponsorLink = true
 		}
+	}
+	if !hasSponsorLink {
+		pass.ReportResult(pass.AnalyzerName, sponsorshiplink, recommendation, explanation)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/sponsorshiplink/sponsorshiplink_test.go
+++ b/pkg/analysis/passes/sponsorshiplink/sponsorshiplink_test.go
@@ -13,30 +13,47 @@ import (
 )
 
 func TestValidSponsorshipLink(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	const pluginJsonContent = `{
-		"name": "my plugin name",
-		"info": {
-		"links": [
-			{
-			"url": "https://example.com/sponsorMe",
-			"name": "sponsorship"
-			}
-		]
-		}
-	}`
-	pass := &analysis.Pass{
-		RootDir: filepath.Join("./"),
-		ResultOf: map[*analysis.Analyzer]interface{}{
-			metadata.Analyzer: []byte(pluginJsonContent),
-			archive.Analyzer:  filepath.Join("."),
-		},
-		Report: interceptor.ReportInterceptor(),
+	testCases := []struct {
+		name     string
+		linkName string
+		url      string
+	}{
+		{"sponsorship as name", "sponsorship", "https://example.com/sponsorMe"},
+		{"sponsor as name", "Sponsor", "https://example.com/becomeSponsor"},
 	}
 
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 0)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var interceptor testpassinterceptor.TestPassInterceptor
+			pluginJsonContent := `{
+				"name": "my plugin name",
+				"info": {
+				"links": [
+				{
+					"url": "https://example.com/website",
+					"name": "Website"
+				},	
+				{
+					"url": "` + tc.url + `",
+					"name": "` + tc.linkName + `"
+				}
+			]
+			}
+			}`
+			pass := &analysis.Pass{
+				RootDir: filepath.Join("./"),
+				ResultOf: map[*analysis.Analyzer]interface{}{
+					metadata.Analyzer: []byte(pluginJsonContent),
+					archive.Analyzer:  filepath.Join("."),
+				},
+				Report: interceptor.ReportInterceptor(),
+			}
+
+			_, err := Analyzer.Run(pass)
+			require.NoError(t, err)
+			require.Len(t, interceptor.Diagnostics, 0)
+		})
+	}
 }
 
 func TestNoSponsorshipLink(t *testing.T) {


### PR DESCRIPTION
Sponsor link pass has to check all the links entries for sponsor link. 
Previous version was returning `no sponsor link present` report when one of the entry does not contain `sponsor|sponsorship` string.

Ex:
<pre>
"links": [
      {
        "name": "Website", -- <b>returns the report due to not containing sponsor|sponsorship </b>
        "url": "https://github.com/hoptical/grafana-kafka-datasource"
      },
      {
        "name": "License",
        "url": "https://github.com/hoptical/grafana-kafka-datasource/blob/main/LICENSE"
      },
      {
        "name": "Sponsor",
        "url": "https://github.com/sponsors/hoptical"
      }
    ],
</pre>