### PR TITLE
Remove __grafanaSceneContext from invalid window properties check

### DIFF
--- a/pkg/analysis/passes/coderules/coderules_test.go
+++ b/pkg/analysis/passes/coderules/coderules_test.go
@@ -220,10 +220,6 @@ func TestWindowAccessWindowObjects(t *testing.T) {
 			"Detected access to restricted window property: window.grafanaRuntime. Accessing window.grafanaRuntime is not permitted.",
 			"Code rule violation found in testdata/access-window/src/index.ts at line 4",
 		},
-		{
-			"Detected access to restricted window property: window.__grafanaSceneContext. Accessing window.__grafanaSceneContext is not permitted.",
-			"Code rule violation found in testdata/access-window/src/index.ts at line 5",
-		},
 	}
 
 	// Test all expectations in a loop

--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -163,7 +163,6 @@ rules:
     pattern-either:
       - pattern-regex: window\.(grafanaBootData)
       - pattern-regex: window\.(grafanaRuntime)
-      - pattern-regex: window\.(__grafanaSceneContext)
     paths:
       include:
         - "src/**/*.ts"

--- a/pkg/analysis/passes/coderules/testdata/access-window/src/index.ts
+++ b/pkg/analysis/passes/coderules/testdata/access-window/src/index.ts
@@ -2,5 +2,4 @@ function test() {
   window.grafanaBootData;
   window.grafanaBootData.testProp;
   window.grafanaRuntime;
-  window.__grafanaSceneContext;
 }


### PR DESCRIPTION
Draft whilst I do some chasing to understand best way forward...

I originally asked for this to be added in [this issue](https://github.com/grafana/plugin-validator/issues/322) to checks but we have no public API right now to access current scenes dashboards model which makes the error message confusing for plugin developers who during submission receive the error and come asking us what they should do.

e.g. https://grafana.zendesk.com/agent/tickets/197700