### PR TITLE
Improve reportall reports (part 1)

### DIFF
--- a/pkg/analysis/passes/archive/archive.go
+++ b/pkg/analysis/passes/archive/archive.go
@@ -36,11 +36,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	if emptyArchive.ReportAll {
-		emptyArchive.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, emptyArchive, "Archive is not empty", "")
-	}
-
 	if len(fis) != 1 {
 		pass.ReportResult(
 			pass.AnalyzerName,
@@ -53,10 +48,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		)
 		return nil, nil
 	}
-	if moreThanOneDir.ReportAll {
-		moreThanOneDir.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, moreThanOneDir, "Archive has a single directory", "")
-	}
 
 	if !fis[0].IsDir() {
 		pass.ReportResult(
@@ -67,10 +58,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		)
 		return nil, nil
 	}
-	if noRootDir.ReportAll {
-		noRootDir.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, noRootDir, "Archive contains a root directory", "")
-	}
 
 	rootDir := filepath.Join(pass.RootDir, fis[0].Name())
 	legacyRoot := filepath.Join(rootDir, "dist")
@@ -78,10 +65,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	_, err = os.Stat(legacyRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if dist.ReportAll {
-				dist.Severity = analysis.OK
-				pass.ReportResult(pass.AnalyzerName, dist, "Archive has expected content", "")
-			}
 			return rootDir, nil
 		}
 		return nil, err

--- a/pkg/analysis/passes/archivename/archivename.go
+++ b/pkg/analysis/passes/archivename/archivename.go
@@ -62,11 +62,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			fmt.Sprintf("Archive should contain a directory named %s", data.ID),
 			"The plugin archive file should contain a directory named after the plugin ID. This directory should contain the plugin's dist files. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
 		)
-	} else {
-		if noIdentRootDir.ReportAll {
-			noIdentRootDir.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, noIdentRootDir, fmt.Sprintf("Archive contains directory named %s", data.ID), "")
-		}
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/brokenlinks/brokenlinks.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks.go
@@ -93,10 +93,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				context: "README.md",
 				url:     path,
 			})
-			if relativeLink.ReportAll {
-				relativeLink.Severity = analysis.OK
-				pass.ReportResult(pass.AnalyzerName, relativeLink, fmt.Sprintf("README.md: Link has absolute path: %s", path), "")
-			}
 		} else {
 			pass.ReportResult(pass.AnalyzerName, relativeLink, fmt.Sprintf("README.md: convert relative link to absolute: %s", path), "README.md contains relative links. These links will not work on the Grafana plugin's catalog. Convert them to absolute links. (starting with https://)")
 		}
@@ -122,7 +118,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				brokenCh <- urlstatus{url: url.url, status: err.Error(), context: url.context}
 				return
 			}
-			req.Header.Add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0")
+			req.Header.Add(
+				"User-Agent",
+				"Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0",
+			)
 
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
@@ -145,7 +144,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	reportCount := 0
 	for link := range brokenCh {
 		brokenLink.Severity = analysis.Warning
-		pass.ReportResult(pass.AnalyzerName, brokenLink, fmt.Sprintf("%s: possible broken link: %s (%s)", link.context, link.url, link.status), "README.md might contain broken links. Check that all links are valid and publicly accessible.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			brokenLink,
+			fmt.Sprintf("%s: possible broken link: %s (%s)", link.context, link.url, link.status),
+			"README.md might contain broken links. Check that all links are valid and publicly accessible.",
+		)
 		reportCount++
 	}
 	if reportCount == 0 && brokenLink.ReportAll {

--- a/pkg/analysis/passes/checksum/checksum.go
+++ b/pkg/analysis/passes/checksum/checksum.go
@@ -89,6 +89,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		)
 	}
 
+	if checksumInvalid.ReportAll {
+		checksumInvalid.Severity = analysis.OK
+		pass.ReportResult(
+			pass.AnalyzerName,
+			checksumInvalid,
+			fmt.Sprintf("The provided checksum %s matches the plugin archive", checksum),
+			"The plugin archive matches the provided checksum in the submission form.",
+		)
+	}
+
 	return nil, nil
 }
 

--- a/pkg/analysis/passes/discoverability/discoverability.go
+++ b/pkg/analysis/passes/discoverability/discoverability.go
@@ -10,6 +10,7 @@ import (
 var (
 	emptyDescription = &analysis.Rule{Name: "empty-description", Severity: analysis.Warning}
 	emptyKeywords    = &analysis.Rule{Name: "empty-keywords", Severity: analysis.Warning}
+	hasKeywords      = &analysis.Rule{Name: "has-keywords", Severity: analysis.OK}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -35,11 +36,30 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if data.Info.Description == "" {
-		pass.ReportResult(pass.AnalyzerName, emptyDescription, "plugin.json: description is empty", "Consider providing a plugin description for better discoverability.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			emptyDescription,
+			"plugin.json: description is empty",
+			"Consider providing a plugin description for better discoverability.",
+		)
 	}
 
 	if len(data.Info.Keywords) == 0 {
-		pass.ReportResult(pass.AnalyzerName, emptyKeywords, "plugin.json: keywords are empty", "Consider providing plugin keywords for better discoverability.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			emptyKeywords,
+			"plugin.json: keywords are empty",
+			"Consider providing plugin keywords for better discoverability.",
+		)
+	}
+
+	if hasKeywords.ReportAll {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			hasKeywords,
+			"plugin.json: keywords and description are not empty",
+			"",
+		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/gomanifest/gomanifest.go
+++ b/pkg/analysis/passes/gomanifest/gomanifest.go
@@ -24,6 +24,7 @@ var (
 	noGoManifest      = &analysis.Rule{Name: "no-go-manifest", Severity: analysis.Error}
 	invalidGoManifest = &analysis.Rule{Name: "invalid-go-manifest", Severity: analysis.Error}
 	goManifestIssue   = &analysis.Rule{Name: "go-manifest-issue", Severity: analysis.Error}
+	hasGoManifest     = &analysis.Rule{Name: "has-go-manifest", Severity: analysis.OK}
 )
 
 type ManifestIssue struct {
@@ -70,6 +71,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	if err != nil {
 		return nil, nil
 	}
+
 	if len(goFiles) == 0 {
 		// no go files found so we can't check the manifest
 		return nil, nil
@@ -110,6 +112,15 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				issue.file,
 			),
 			issue.err.Error(),
+		)
+	}
+
+	if len(issues) == 0 && hasGoManifest.ReportAll {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			hasGoManifest,
+			"Go manifest file found",
+			"Plugin has a valid go files manifest signature",
 		)
 	}
 


### PR DESCRIPTION
Part 1 of cleaning up and adding better "ReportAll" reports

The aim is to have ReportALL reporting "good" checks on plugins

- **Clean up unnecessary report all**
- **remove unncessary report all**
- **add report all**
- **start reporting no code violations**
- **report good keywords**
- **report all for go manifest found**
- **report when gosec passes well**
