### PR TITLE
 chore: clean up unnecessary report all (part 3)

### DIFF
--- a/pkg/analysis/passes/coderules/coderules.go
+++ b/pkg/analysis/passes/coderules/coderules.go
@@ -30,14 +30,6 @@ var (
 		Name:     "no-code-rules-violations",
 		Severity: analysis.OK,
 	}
-	semgrepNotFound = &analysis.Rule{
-		Name:     "semgrep-not-found",
-		Severity: analysis.Warning,
-	}
-	semgrepRunningErr = &analysis.Rule{
-		Name:     "semgrep-running-err",
-		Severity: analysis.Warning,
-	}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -48,8 +40,6 @@ var Analyzer = &analysis.Analyzer{
 		codeRulesViolationError,
 		codeRulesViolationWarning,
 		noCodeRulesViolations,
-		semgrepNotFound,
-		semgrepRunningErr,
 	},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "Code Rules",
@@ -58,7 +48,7 @@ var Analyzer = &analysis.Analyzer{
 	},
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
 	if !ok {
 		// no source code for the validator

--- a/pkg/analysis/passes/manifest/manifest.go
+++ b/pkg/analysis/passes/manifest/manifest.go
@@ -39,6 +39,8 @@ var Analyzer = &analysis.Analyzer{
 		emptyManifest,
 		wrongManifest,
 		invalidShaSum,
+		invalidSignature,
+		wrongPermissions,
 		validManifest,
 	},
 	ReadmeInfo: analysis.ReadmeInfo{

--- a/pkg/analysis/passes/nestedmetadata/nestedmetadata.go
+++ b/pkg/analysis/passes/nestedmetadata/nestedmetadata.go
@@ -79,11 +79,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					"A plugin.json file is required to describe the plugin. No plugin.json was found in your plugin archive.",
 				)
 				return nil, nil
-			} else {
-				if missingMetadata.ReportAll {
-					missingMetadata.Severity = analysis.OK
-					pass.ReportResult(pass.AnalyzerName, missingMetadata, "plugin.json exists", "")
-				}
 			}
 			return nil, nil
 		}

--- a/pkg/analysis/passes/org/org.go
+++ b/pkg/analysis/passes/org/org.go
@@ -12,7 +12,10 @@ import (
 )
 
 var (
-	missingGrafanaCloudAccount = &analysis.Rule{Name: "missing-grafanacloud-account", Severity: analysis.Warning}
+	missingGrafanaCloudAccount = &analysis.Rule{
+		Name:     "missing-grafanacloud-account",
+		Severity: analysis.Warning,
+	}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -53,16 +56,16 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	_, err := client.FindOrgBySlug(username)
 	if err != nil {
 		if errors.Is(err, grafana.ErrOrganizationNotFound) {
-			pass.ReportResult(pass.AnalyzerName, missingGrafanaCloudAccount, fmt.Sprintf("unregistered Grafana Cloud account: %s", username), "The plugin's ID is prefixed with a Grafana Cloud account name, but that account does not exist. Please create the account or correct the name.")
+			pass.ReportResult(
+				pass.AnalyzerName,
+				missingGrafanaCloudAccount,
+				fmt.Sprintf("unregistered Grafana Cloud account: %s", username),
+				"The plugin's ID is prefixed with a Grafana Cloud account name, but that account does not exist. Please create the account or correct the name.",
+			)
 		} else if errors.Is(err, grafana.ErrPrivateOrganization) {
 			return nil, nil
 		}
 		return nil, err
-	} else {
-		if missingGrafanaCloudAccount.ReportAll {
-			missingGrafanaCloudAccount.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, missingGrafanaCloudAccount, fmt.Sprintf("found Grafana Cloud account: %s", username), "")
-		}
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/osvscanner/osvscanner.go
+++ b/pkg/analysis/passes/osvscanner/osvscanner.go
@@ -103,15 +103,6 @@ func run(pass *analysis.Pass) (interface{}, error) {
 						"osv-scanner failed to run",
 						fmt.Sprintf("osv-scanner failed to run: %s", err.Error()))
 				}
-			} else {
-				scanningFailure.Severity = analysis.OK
-				if scanningFailure.ReportAll {
-					pass.ReportResult(
-						pass.AnalyzerName,
-						scanningFailure,
-						"osv-scanner successfully ran",
-						"osv-scanner successfully ran")
-				}
 			}
 
 			filteredResults := FilterOSVResults(data, lockFile)
@@ -161,31 +152,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 									message)
 								criticalSeverityCount++
 							case SeverityHigh:
-								if osvScannerHighSeverityDetected.ReportAll {
-									pass.ReportResult(
-										pass.AnalyzerName,
-										osvScannerHighSeverityDetected,
-										"osv-scanner detected a high severity issue",
-										message)
-								}
 								highSeverityCount++
 							case SeverityModerate:
-								if osvScannerModerateSeverityDetected.ReportAll {
-									pass.ReportResult(
-										pass.AnalyzerName,
-										osvScannerModerateSeverityDetected,
-										"osv-scanner detected a moderate severity issue",
-										message)
-								}
 								moderateSeverityCount++
 							case SeverityLow:
-								if osvScannerLowSeverityDetected.ReportAll {
-									pass.ReportResult(
-										pass.AnalyzerName,
-										osvScannerLowSeverityDetected,
-										"osv-scanner detected a low severity issue",
-										message)
-								}
 								lowSeverityCount++
 							}
 						}

--- a/pkg/analysis/passes/pluginname/pluginname.go
+++ b/pkg/analysis/passes/pluginname/pluginname.go
@@ -42,12 +42,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	if data.ID != "" && data.Name != "" && data.ID == data.Name {
-		pass.ReportResult(pass.AnalyzerName, humanFriendlyName, "plugin.json: plugin name should be human-friendly", "The plugin name should be human-friendly and not the same as the plugin id. The plugin name is used in the UI and should be descriptive and easy to read.")
-	} else {
-		if humanFriendlyName.ReportAll {
-			humanFriendlyName.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, humanFriendlyName, "plugin.json: plugin name is human-friendly", "")
-		}
+		pass.ReportResult(
+			pass.AnalyzerName,
+			humanFriendlyName,
+			"plugin.json: plugin name should be human-friendly",
+			"The plugin name should be human-friendly and not the same as the plugin id. The plugin name is used in the UI and should be descriptive and easy to read.",
+		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/readme/readme.go
+++ b/pkg/analysis/passes/readme/readme.go
@@ -35,18 +35,24 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	b, err := os.ReadFile(filepath.Join(archiveDir, "README.md"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			pass.ReportResult(pass.AnalyzerName, missingReadme, "missing README.md", "A README.md file is required for plugins. The contents of the file will be displayed in the Plugin catalog.")
+			pass.ReportResult(
+				pass.AnalyzerName,
+				missingReadme,
+				"missing README.md",
+				"A README.md file is required for plugins. The contents of the file will be displayed in the Plugin catalog.",
+			)
 			return nil, nil
 		}
 		return nil, err
 	}
 	if len(strings.TrimSpace(string(b))) == 0 {
-		pass.ReportResult(pass.AnalyzerName, missingReadme, "README.md is empty", "A README.md file is required for plugins. The contents of the file will be displayed in the Plugin catalog.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			missingReadme,
+			"README.md is empty",
+			"A README.md file is required for plugins. The contents of the file will be displayed in the Plugin catalog.",
+		)
 		return nil, nil
-	}
-	if missingReadme.ReportAll {
-		missingReadme.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, missingReadme, "README.md: exists", "")
 	}
 
 	readmeContent := string(b)
@@ -60,10 +66,5 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	if len(comment) > 0 {
 		pass.ReportResult(pass.AnalyzerName, readmeComment, "README.md contains comment(s).", "")
 	}
-	if readmeComment.ReportAll {
-		readmeComment.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, readmeComment, "README.md does not contain any comments.", "")
-	}
-
 	return b, nil
 }

--- a/pkg/analysis/passes/restrictivedep/restrictivedep.go
+++ b/pkg/analysis/passes/restrictivedep/restrictivedep.go
@@ -11,8 +11,14 @@ import (
 )
 
 var (
-	dependsOnPatchReleases = &analysis.Rule{Name: "depends-on-patch-releases", Severity: analysis.Warning}
-	dependsOnSingleRelease = &analysis.Rule{Name: "depends-on-single-release", Severity: analysis.Warning}
+	dependsOnPatchReleases = &analysis.Rule{
+		Name:     "depends-on-patch-releases",
+		Severity: analysis.Warning,
+	}
+	dependsOnSingleRelease = &analysis.Rule{
+		Name:     "depends-on-single-release",
+		Severity: analysis.Warning,
+	}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -47,23 +53,30 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	if regexp.MustCompile("^[0-9]+.[0-9]+.x$").Match([]byte(data.Dependencies.GrafanaDependency)) {
 		version := strings.TrimSuffix(data.Dependencies.GrafanaDependency, ".x")
-		pass.ReportResult(pass.AnalyzerName, dependsOnPatchReleases, fmt.Sprintf("plugin.json: grafanaDependency only targets patch releases of Grafana %s", version), "The plugin will only work in patch releases of the specified minor Grafana version.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			dependsOnPatchReleases,
+			fmt.Sprintf(
+				"plugin.json: grafanaDependency only targets patch releases of Grafana %s",
+				version,
+			),
+			"The plugin will only work in patch releases of the specified minor Grafana version.",
+		)
 		return nil, nil
-	} else {
-		if dependsOnPatchReleases.ReportAll {
-			dependsOnPatchReleases.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, dependsOnPatchReleases, "plugin.json: grafanaDependency correctly targets patch releases of Grafana", "")
-		}
 	}
 
-	if regexp.MustCompile("^[0-9]+.[0-9]+.[0-9]+$").Match([]byte(data.Dependencies.GrafanaDependency)) {
-		pass.ReportResult(pass.AnalyzerName, dependsOnSingleRelease, fmt.Sprintf("plugin.json: grafanaDependency only targets Grafana %s", data.Dependencies.GrafanaDependency), "The plugin will only work in the specific version of Grafana down to patch version.")
+	if regexp.MustCompile("^[0-9]+.[0-9]+.[0-9]+$").
+		Match([]byte(data.Dependencies.GrafanaDependency)) {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			dependsOnSingleRelease,
+			fmt.Sprintf(
+				"plugin.json: grafanaDependency only targets Grafana %s",
+				data.Dependencies.GrafanaDependency,
+			),
+			"The plugin will only work in the specific version of Grafana down to patch version.",
+		)
 		return nil, nil
-	} else {
-		if dependsOnSingleRelease.ReportAll {
-			dependsOnSingleRelease.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, dependsOnSingleRelease, "plugin.json: grafanaDependency does not target single release of Grafana", "")
-		}
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/screenshots/screenshots.go
+++ b/pkg/analysis/passes/screenshots/screenshots.go
@@ -60,7 +60,12 @@ func checkScreenshots(pass *analysis.Pass) (interface{}, error) {
 
 	if len(data.Info.Screenshots) == 0 {
 		explanation := "Screenshots are displayed in the Plugin catalog. Please add at least one screenshot to your plugin.json."
-		pass.ReportResult(pass.AnalyzerName, screenshots, "plugin.json: should include screenshots for the Plugin catalog", explanation)
+		pass.ReportResult(
+			pass.AnalyzerName,
+			screenshots,
+			"plugin.json: should include screenshots for the Plugin catalog",
+			explanation,
+		)
 		return data.Info.Screenshots, nil
 	}
 
@@ -68,7 +73,12 @@ func checkScreenshots(pass *analysis.Pass) (interface{}, error) {
 	for _, screenshot := range data.Info.Screenshots {
 		if strings.TrimSpace(screenshot.Path) == "" {
 			reportCount++
-			pass.ReportResult(pass.AnalyzerName, screenshots, fmt.Sprintf("plugin.json: invalid empty screenshot path: %q", screenshot.Name), "The screenshot path must not be empty.")
+			pass.ReportResult(
+				pass.AnalyzerName,
+				screenshots,
+				fmt.Sprintf("plugin.json: invalid empty screenshot path: %q", screenshot.Name),
+				"The screenshot path must not be empty.",
+			)
 		} else if err := validateImage(filepath.Join(archiveDir, screenshot.Path)); err != nil {
 			reportCount++
 			logme.Debugln(err)
@@ -79,17 +89,6 @@ func checkScreenshots(pass *analysis.Pass) (interface{}, error) {
 	if reportCount > 0 {
 		return nil, nil
 	}
-
-	if screenshots.ReportAll {
-		screenshots.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, screenshots, "plugin.json: includes screenshots for the Plugin catalog", "")
-	}
-
-	if screenshotsType.ReportAll {
-		screenshotsType.Severity = analysis.OK
-		pass.ReportResult(pass.AnalyzerName, screenshotsType, "screenshots are valid image type", "")
-	}
-
 	return data.Info.Screenshots, nil
 }
 
@@ -120,7 +119,8 @@ func validateImage(imgPath string) error {
 	// returns text/plain or text/xml for svg files
 	mimeType := http.DetectContentType(buffer)
 	// logo.svg returns text/plain, valid.svg returns text/xml
-	if (strings.Contains(mimeType, "text/plain") || strings.Contains(mimeType, "text/xml")) && checkSVG(buffer) {
+	if (strings.Contains(mimeType, "text/plain") || strings.Contains(mimeType, "text/xml")) &&
+		checkSVG(buffer) {
 		mimeType = svgImage
 	}
 
@@ -130,5 +130,9 @@ func validateImage(imgPath string) error {
 		}
 	}
 
-	return fmt.Errorf("invalid screenshot image: %q. Accepted image types: %q", imgPath, acceptedImageTypes)
+	return fmt.Errorf(
+		"invalid screenshot image: %q. Accepted image types: %q",
+		imgPath,
+		acceptedImageTypes,
+	)
 }

--- a/pkg/analysis/passes/sdkusage/sdkusage.go
+++ b/pkg/analysis/passes/sdkusage/sdkusage.go
@@ -191,7 +191,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			req.New.Path != "github.com/grafana/grafana-plugin-sdk-go" {
 			pass.ReportResult(
 				pass.AnalyzerName,
-				goSdkNotUsed,
+				goSdkReplaced,
 				"Your plugin is using a custom or forked version of the Grafana Go SDK",
 				"Custom or forked version of Grafana Go SDK are not supported. Please use the latest Grafana Go SDK (github.com/grafana/grafana-plugin-sdk-go)",
 			)

--- a/pkg/analysis/passes/signature/signature.go
+++ b/pkg/analysis/passes/signature/signature.go
@@ -26,7 +26,7 @@ var (
 	modifiedSignature = &analysis.Rule{Name: "modified-signature", Severity: analysis.Warning}
 	invalidSignature  = &analysis.Rule{Name: "invalid-signature", Severity: analysis.Warning}
 	privateSignature  = &analysis.Rule{Name: "private-signature", Severity: analysis.Warning}
-	validSignature    = &analysis.Rule{Name: "invalid-signature", Severity: analysis.OK}
+	validSignature    = &analysis.Rule{Name: "valid-signature", Severity: analysis.OK}
 )
 
 var Analyzer = &analysis.Analyzer{

--- a/pkg/analysis/passes/signature/signature.go
+++ b/pkg/analysis/passes/signature/signature.go
@@ -26,13 +26,20 @@ var (
 	modifiedSignature = &analysis.Rule{Name: "modified-signature", Severity: analysis.Warning}
 	invalidSignature  = &analysis.Rule{Name: "invalid-signature", Severity: analysis.Warning}
 	privateSignature  = &analysis.Rule{Name: "private-signature", Severity: analysis.Warning}
+	validSignature    = &analysis.Rule{Name: "invalid-signature", Severity: analysis.OK}
 )
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "signature",
 	Requires: []*analysis.Analyzer{manifest.Analyzer, metadata.Analyzer},
 	Run:      run,
-	Rules:    []*analysis.Rule{unsignedPlugin, modifiedSignature, invalidSignature, privateSignature},
+	Rules: []*analysis.Rule{
+		unsignedPlugin,
+		modifiedSignature,
+		invalidSignature,
+		privateSignature,
+		validSignature,
+	},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:        "Signature",
 		Description: "Ensures the plugin has a valid signature.",
@@ -67,7 +74,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	state, err := getPluginSignatureState(data.ID, data.Info.Version, archiveDir, mf)
 	if err != nil {
-		pass.ReportResult(pass.AnalyzerName, invalidSignature, "MANIFEST.txt: failed to check plugin signature", err.Error())
+		pass.ReportResult(
+			pass.AnalyzerName,
+			invalidSignature,
+			"MANIFEST.txt: failed to check plugin signature",
+			err.Error(),
+		)
 		return nil, nil
 	}
 
@@ -75,17 +87,27 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	case PluginSignatureUnsigned:
 		pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "unsigned plugin", "")
 	case PluginSignatureInvalid:
-		pass.ReportResult(pass.AnalyzerName, invalidSignature, "MANIFEST.txt: invalid plugin signature", "The plugin might had been modified after it was signed.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			invalidSignature,
+			"MANIFEST.txt: invalid plugin signature",
+			"The plugin might had been modified after it was signed.",
+		)
 	case PluginSignatureModified:
-		pass.ReportResult(pass.AnalyzerName, modifiedSignature, "MANIFEST.txt: plugin has been modified since it was signed", "The plugin might had been modified after it was signed.")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			modifiedSignature,
+			"MANIFEST.txt: plugin has been modified since it was signed",
+			"The plugin might had been modified after it was signed.",
+		)
 	default:
-		if unsignedPlugin.ReportAll {
-			unsignedPlugin.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, unsignedPlugin, "MANIFEST.txt: plugin is signed", "")
-			invalidSignature.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, invalidSignature, "MANIFEST.txt: valid plugin signature", "")
-			modifiedSignature.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, modifiedSignature, "MANIFEST.txt: plugin has not been modified since it was signed", "")
+		if validSignature.ReportAll {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				validSignature,
+				"MANIFEST.txt: valid plugin signature",
+				"",
+			)
 		}
 	}
 
@@ -96,12 +118,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		if m.SignatureType == "private" {
-			pass.ReportResult(pass.AnalyzerName, privateSignature, "MANIFEST.txt: plugin must be signed under community or commercial signature level", "The plugin is signed under private signature level.")
-		} else {
-			if privateSignature.ReportAll {
-				privateSignature.Severity = analysis.OK
-				pass.ReportResult(pass.AnalyzerName, privateSignature, "MANIFEST.txt: plugin is signed under community or commercial signature level", "")
-			}
+			pass.ReportResult(
+				pass.AnalyzerName,
+				privateSignature,
+				"MANIFEST.txt: plugin must be signed under community or commercial signature level",
+				"The plugin is signed under private signature level.",
+			)
 		}
 	}
 
@@ -143,7 +165,10 @@ func checkFileSignature(fp string, expHash string) error {
 	return nil
 }
 
-func getPluginSignatureState(pluginID, version, pluginDir string, byteValue []byte) (PluginSignature, error) {
+func getPluginSignatureState(
+	pluginID, version, pluginDir string,
+	byteValue []byte,
+) (PluginSignature, error) {
 	if len(byteValue) < 10 {
 		return PluginSignatureUnsigned, nil
 	}

--- a/pkg/analysis/passes/sourcecode/sourcecode.go
+++ b/pkg/analysis/passes/sourcecode/sourcecode.go
@@ -12,14 +12,6 @@ var (
 		Name:     "source-code-not-provided",
 		Severity: analysis.Warning,
 	}
-	sourceCodeNotFound = &analysis.Rule{
-		Name:     "source-code-not-found",
-		Severity: analysis.Error,
-	}
-	sourceCodeVersionMisMatch = &analysis.Rule{
-		Name:     "source-code-version-mismatch",
-		Severity: analysis.Error,
-	}
 )
 
 var Analyzer = &analysis.Analyzer{
@@ -27,8 +19,6 @@ var Analyzer = &analysis.Analyzer{
 	Requires: []*analysis.Analyzer{metadata.Analyzer},
 	Run:      run,
 	Rules: []*analysis.Rule{
-		sourceCodeNotFound,
-		sourceCodeVersionMisMatch,
 		sourceCodeNotProvided,
 	},
 	ReadmeInfo: analysis.ReadmeInfo{

--- a/pkg/analysis/passes/templatereadme/templatereadme.go
+++ b/pkg/analysis/passes/templatereadme/templatereadme.go
@@ -28,15 +28,17 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	re := regexp.MustCompile("(?i)Grafana (Panel|Data Source|Datasource|App|Data Source Backend) Plugin Template")
+	re := regexp.MustCompile(
+		"(?i)Grafana (Panel|Data Source|Datasource|App|Data Source Backend) Plugin Template",
+	)
 
 	if m := re.Find(readmeResult); m != nil {
-		pass.ReportResult(pass.AnalyzerName, templateReadme, "README.md: uses README from template", "The README.md file uses the README from the plugin template. Please update it to describe your plugin.")
-	} else {
-		if templateReadme.ReportAll {
-			templateReadme.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, templateReadme, "README.md: does not use README from template", "")
-		}
+		pass.ReportResult(
+			pass.AnalyzerName,
+			templateReadme,
+			"README.md: uses README from template",
+			"The README.md file uses the README from the plugin template. Please update it to describe your plugin.",
+		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/typesuffix/typesuffix.go
+++ b/pkg/analysis/passes/typesuffix/typesuffix.go
@@ -2,7 +2,6 @@ package typesuffix
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -42,12 +41,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	idParts := strings.Split(data.ID, "-")
 
 	if idParts[len(idParts)-1] != data.Type {
-		pass.ReportResult(pass.AnalyzerName, pluginTypeSuffix, "plugin.json: plugin id should end with plugin type", "E.g. \"my-plugin-name\" (a data source plugin), should be: \"my-plugin-datasource\"")
-	} else {
-		if pluginTypeSuffix.ReportAll {
-			pluginTypeSuffix.Severity = analysis.OK
-			pass.ReportResult(pass.AnalyzerName, pluginTypeSuffix, fmt.Sprintf("plugin.json: plugin id ends with plugin type: %s", data.Type), "")
-		}
+		pass.ReportResult(
+			pass.AnalyzerName,
+			pluginTypeSuffix,
+			"plugin.json: plugin id should end with plugin type",
+			"E.g. \"my-plugin-name\" (a data source plugin), should be: \"my-plugin-datasource\"",
+		)
 	}
 
 	return nil, nil

--- a/pkg/analysis/passes/virusscan/virusscan.go
+++ b/pkg/analysis/passes/virusscan/virusscan.go
@@ -19,6 +19,10 @@ var (
 		Name:     "virus-scan-failed",
 		Severity: analysis.Error,
 	}
+	virusScanPassed = &analysis.Rule{
+		Name:     "virus-scan-passed",
+		Severity: analysis.OK,
+	}
 )
 
 type ClamAvScanSummary struct {
@@ -41,6 +45,7 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 	Rules: []*analysis.Rule{
 		virusScanFailed,
+		virusScanPassed,
 	},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "Virus Scan",
@@ -124,6 +129,15 @@ func runClamavScan(clamavBin string, path string, entityName string, pass *analy
 			),
 			fmt.Sprintf("Files found by ClamAV: %s", strings.Join(scanSummary.FoundFiles, ", ")),
 		)
+	} else {
+		if virusScanPassed.ReportAll {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				virusScanPassed,
+				"ClamAV found no infected files",
+				"",
+			)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
follow up to https://github.com/grafana/plugin-validator/pull/373

it removes several unnecessary report all and adds some better new ones

This removes osvscanner tests for report all of individual reports that are too much to send in the validator output

This PR also removes some Rules that were not used and fixes the name of a couple that were misplaced.