### PR TITLE
brokenurls: do not report 429 errors in github urls

### DIFF
--- a/pkg/analysis/passes/brokenlinks/brokenlinks.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks.go
@@ -149,6 +149,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
+				if isGitHubURL(url.url) && strings.Contains(resp.Status, "429 Too Many Requests") {
+					return
+				}
 				brokenCh <- urlstatus{url: url.url, status: resp.Status, context: url.context}
 			}
 		}(u)

--- a/pkg/analysis/passes/brokenlinks/brokenlinks.go
+++ b/pkg/analysis/passes/brokenlinks/brokenlinks.go
@@ -149,7 +149,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				if isGitHubURL(url.url) && strings.Contains(resp.Status, "429 Too Many Requests") {
+				if resp.StatusCode == http.StatusTooManyRequests {
 					return
 				}
 				brokenCh <- urlstatus{url: url.url, status: resp.Status, context: url.context}


### PR DESCRIPTION
seems sending authentication token as implemented in https://github.com/grafana/plugin-validator/pull/375 will not work for github we can simply skip 429 errors for github urls
