### PR TITLE
osv scanner: report individual high severity issues

### DIFF
--- a/pkg/analysis/passes/osvscanner/osvscanner.go
+++ b/pkg/analysis/passes/osvscanner/osvscanner.go
@@ -145,6 +145,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 									message)
 								criticalSeverityCount++
 							case SeverityHigh:
+								pass.ReportResult(
+									pass.AnalyzerName,
+									osvScannerHighSeverityDetected,
+									"osv-scanner detected a high severity issue",
+									message,
+								)
 								highSeverityCount++
 							}
 						}

--- a/pkg/analysis/passes/osvscanner/osvscanner_test.go
+++ b/pkg/analysis/passes/osvscanner/osvscanner_test.go
@@ -109,12 +109,13 @@ func TestOSVScannerAsLibrary(t *testing.T) {
 	// restore default
 	doScanInternal = actualFunction
 	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 3)
+	require.Len(t, interceptor.Diagnostics, 4)
 
-	// this results in three issues: 1 individual critical, 1 critical summary, 1 high summary
+	// this results in three issues: 1 individual critical, 1 critical summary, 1 individual high, 1 high summary
 	messages := []string{
 		"osv-scanner detected a critical severity issue",
 		"osv-scanner detected critical severity issues",
+		"osv-scanner detected a high severity issue",
 		"osv-scanner detected high severity issues",
 	}
 	titles := interceptor.GetTitles()


### PR DESCRIPTION
This PR reports individual high severity issues flagged by osv-scanner, similar to how we treat critical issues. Before, it would only report a summary with the number of high-severity vulnerabilities found. high-severity vulnerabilities are errors, not warnings, so without this change it's hard to detect which dependencies to bump to fix the vulnerabilities and make the validator pass.

Example before:

```
error: osv-scanner detected high severity issues
detail: osv-scanner detected 2 unique high severity issues for lockfile: /tmp/validator3611935275/yarn.lock
``` 

Example after:

```
error: osv-scanner detected a high severity issue
detail: SEVERITY: HIGH in package dompurify, vulnerable to CVE-2024-47875
error: osv-scanner detected a high severity issue
detail: SEVERITY: HIGH in package dompurify, vulnerable to CVE-2024-45801
error: osv-scanner detected high severity issues
detail: osv-scanner detected 2 unique high severity issues for lockfile: /tmp/validator139916460/yarn.lock
```

Related to #395.
