### PR TITLE
code rules: error on direct css import

### DIFF
--- a/pkg/analysis/passes/coderules/coderules_test.go
+++ b/pkg/analysis/passes/coderules/coderules_test.go
@@ -266,3 +266,66 @@ func TestOldReactInternals(t *testing.T) {
 		analysis.Warning,
 	)
 }
+
+func TestNoDirectCSSImports(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			sourcecode.Analyzer: filepath.Join("testdata", "no-direct-css-imports"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 3)
+	for i := range interceptor.Diagnostics {
+		require.Equal(t, analysis.Error, interceptor.Diagnostics[i].Severity)
+	}
+}
+
+func TestNoEmotionGlobalImport(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			sourcecode.Analyzer: filepath.Join("testdata", "no-emotion-global-import"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 3)
+	for i := range interceptor.Diagnostics {
+		require.Equal(t, analysis.Error, interceptor.Diagnostics[i].Severity)
+	}
+}
+
+func TestNoDirectCSSImportsGood(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			sourcecode.Analyzer: filepath.Join("testdata", "no-direct-css-imports-good"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}

--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -194,3 +194,25 @@ rules:
     message: "Detected usage of React internal API '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED'. This API is internal to React and should not be used directly as it may break in future React versions."
     languages: [javascript, typescript]
     severity: WARNING
+
+  - id: no-direct-css-imports
+    pattern-either:
+      - pattern-regex: import\s+['"].*\.(css|scss|less)['"]
+      - pattern: import { Global } from '@emotion/react'
+      - pattern: <Global ... />
+      - pattern: <Global />
+    paths:
+      include:
+        - "src/**/*.ts"
+        - "src/**/*.tsx"
+        - "src/**/*.js"
+        - "src/**/*.jsx"
+      exclude:
+        - "*.spec.ts"
+        - "*.spec.tsx"
+        - "*.test.ts"
+        - "*.test.tsx"
+        - "*.js"
+    message: "Direct CSS imports and Emotion UI Global components are not permitted. Use CSS-in-JS solutions like styled-components or emotion's css function instead."
+    languages: [javascript, typescript]
+    severity: ERROR

--- a/pkg/analysis/passes/coderules/testdata/no-direct-css-imports-good/src/index.tsx
+++ b/pkg/analysis/passes/coderules/testdata/no-direct-css-imports-good/src/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from 'styled-components';
+import { css } from '@emotion/react';
+
+const GlobalStyles = styled.div`
+  margin: 0;
+  padding: 0;
+`;
+
+const styles = css`
+  body {
+    margin: 0;
+  }
+`;
+
+export const App = () => (
+  <GlobalStyles>
+    <div>Hello World</div>
+  </GlobalStyles>
+);

--- a/pkg/analysis/passes/coderules/testdata/no-direct-css-imports/src/index.ts
+++ b/pkg/analysis/passes/coderules/testdata/no-direct-css-imports/src/index.ts
@@ -1,0 +1,3 @@
+import './App.css';
+import '../styles.scss';
+import './theme.less';

--- a/pkg/analysis/passes/coderules/testdata/no-emotion-global-import/src/index.tsx
+++ b/pkg/analysis/passes/coderules/testdata/no-emotion-global-import/src/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Global } from '@emotion/react';
+
+export const App = () => (
+  <>
+    <Global styles={{ body: { margin: 0 } }} />
+    <div>Hello</div>
+  </>
+);
+
+const Layout = () => (
+  <>
+    <Global />
+    <main>Content</main>
+  </>
+);


### PR DESCRIPTION
closes https://github.com/grafana/plugin-validator/issues/431

validates that plugins don't import CSS directy. 