### PR TITLE
refactor: add output package and marshaler interface

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -67,6 +67,8 @@ type Diagnostic struct {
 	Name     string
 }
 
+type Diagnostics map[string][]Diagnostic
+
 type Rule struct {
 	Name      string
 	Disabled  bool

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/fatih/color"
+
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
@@ -92,9 +93,9 @@ var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 
 // ExitCode returns the exit code of the CLI program.
 // It returns:
-//   - 1 if there's an error;
-//   - 1 if there's a warning AND strict is true;
-//   - 0 in all other cases.
+// 1 if there's an error;
+// 1 if there's a warning AND strict is true;
+// 0 in all other cases.
 func ExitCode(strict bool, diags analysis.Diagnostics) int {
 	for _, ds := range diags {
 		for _, d := range ds {

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -1,0 +1,98 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/fatih/color"
+	"github.com/grafana/plugin-validator/pkg/analysis"
+)
+
+type Marshaler interface {
+	Marshal(data analysis.Diagnostics) ([]byte, error)
+}
+
+type marshalerFunc func(data analysis.Diagnostics) ([]byte, error)
+
+func (f marshalerFunc) Marshal(data analysis.Diagnostics) ([]byte, error) {
+	return f(data)
+}
+
+type jsonMarshaler struct {
+	id      string
+	version string
+}
+
+func NewJSONMarshaler(id string, version string) Marshaler {
+	return jsonMarshaler{id, version}
+}
+
+type jsonOutput struct {
+	ID          string               `json:"id"`
+	Version     string               `json:"version"`
+	Diagnostics analysis.Diagnostics `json:"plugin-validator"`
+}
+
+func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
+	return json.MarshalIndent(jsonOutput{
+		ID:          j.id,
+		Version:     j.version,
+		Diagnostics: data,
+	}, "", "  ")
+}
+
+var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
+	var buf bytes.Buffer
+	for name := range data {
+		for _, d := range data[name] {
+			switch d.Severity {
+			case analysis.Error:
+				buf.WriteString(color.RedString("error: "))
+			case analysis.Warning:
+				buf.WriteString(color.YellowString("warning: "))
+			case analysis.Recommendation:
+				buf.WriteString(color.CyanString("recommendation: "))
+			case analysis.OK:
+				buf.WriteString(color.GreenString("ok: "))
+			case analysis.SuspectedProblem:
+				buf.WriteString(color.YellowString("suspected: "))
+			}
+
+			if d.Context != "" {
+				buf.WriteString(d.Context + ": ")
+			}
+
+			buf.WriteString(d.Title)
+			if len(d.Detail) > 0 {
+				buf.WriteRune('\n')
+				buf.WriteString(color.BlueString("detail: "))
+				buf.WriteString(d.Detail)
+			}
+			buf.WriteRune('\n')
+		}
+	}
+	return buf.Bytes(), nil
+})
+
+func ExitCode(strict bool, diags analysis.Diagnostics) int {
+	for _, ds := range diags {
+		for _, d := range ds {
+			switch d.Severity {
+			case analysis.Error:
+				return 1
+			case analysis.Warning:
+				if strict {
+					return 1
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Static checks
+
+var (
+	_ = Marshaler(jsonMarshaler{})
+	_ = Marshaler(MarshalCLI)
+)

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -8,21 +8,34 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
+// Marshaler is an interface for encoding the analysis results into bytes.
+// Each implementation outputs the analysis results in a different format.
 type Marshaler interface {
+	// Marshal encodes the diagnostics data in the format implemented by the marshaler.
 	Marshal(data analysis.Diagnostics) ([]byte, error)
 }
 
+// marshalerFunc is an adapter for using normal functions as Marshaler.
 type marshalerFunc func(data analysis.Diagnostics) ([]byte, error)
 
+// Marshal marshals the diagnostics data using the function.
 func (f marshalerFunc) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	return f(data)
 }
 
+// jsonMarshaler is a Marshaler that outputs to JSON format.
 type jsonMarshaler struct {
-	id      string
+	// Additional fields used for JSON output
+
+	// id is the plugin ID
+	id string
+
+	// version is the plugin version
 	version string
 }
 
+// NewJSONMarshaler returns a new Marshaler that outputs the diagnostics data in JSON format.
+// This marshaler requires additional plugin id and plugin version arguments.
 func NewJSONMarshaler(id string, version string) Marshaler {
 	return jsonMarshaler{id, version}
 }
@@ -33,6 +46,8 @@ type jsonOutput struct {
 	Diagnostics analysis.Diagnostics `json:"plugin-validator"`
 }
 
+// Marshal marshals the diagnostics data in JSON format.
+// The additional id and version fields are taken from the marshaler itself.
 func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	return json.MarshalIndent(jsonOutput{
 		ID:          j.id,
@@ -41,6 +56,7 @@ func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	}, "", "  ")
 }
 
+// MarshalCLI is a Marshaler that returns the diagnostics data in a human-readable format, for CLI usage.
 var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	var buf bytes.Buffer
 	for name := range data {
@@ -74,6 +90,11 @@ var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	return buf.Bytes(), nil
 })
 
+// ExitCode returns the exit code of the CLI program.
+// It returns:
+//   - 1 if there's an error;
+//   - 1 if there's a warning AND strict is true;
+//   - 0 in all other cases.
 func ExitCode(strict bool, diags analysis.Diagnostics) int {
 	for _, ds := range diags {
 		for _, d := range ds {

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/grafana/plugin-validator/pkg/analysis/output"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/output"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes"
 	"github.com/grafana/plugin-validator/pkg/archivetool"
 	"github.com/grafana/plugin-validator/pkg/logme"

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -219,7 +219,10 @@ func main() {
 		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
 		os.Exit(1)
 	}
-	_, _ = fmt.Fprintln(outWriter, string(ob))
+	if _, err = fmt.Fprintln(outWriter, string(ob)); err != nil {
+		logme.Errorln(fmt.Errorf("couldn't write output: %w", err))
+		os.Exit(1)
+	}
 	os.Exit(output.ExitCode(*strictFlag, diags))
 }
 

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -170,36 +170,38 @@ func main() {
 
 	var outputMarshaler output.Marshaler
 
-	if *outputToFile != "" || cfg.Global.JSONOutput {
-		// JSON output for either JSON CLI or JSON file
-		pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
-		if err != nil {
-			pluginID, pluginVersion = GetIDAndVersionFallBack(archiveDir)
-			archiveDiag := analysis.Diagnostic{
-				Name:     "zip-invalid",
-				Severity: analysis.Error,
-				Title:    "Plugin archive is improperly structured",
-				Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
-			}
-			diags["archive"] = append(diags["archive"], archiveDiag)
-		}
-		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
-	} else {
-		// CLI output
-		outputMarshaler = output.MarshalCLI
-	}
-	// TODO: gha output
-
-	// Marshal output with the correct marshaler, depending on the config
-	ob, err := outputMarshaler.Marshal(diags)
+	// Plugin ID and version (needed by JSON output)
+	pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
 	if err != nil {
-		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
-		os.Exit(1)
+		pluginID, pluginVersion = GetIDAndVersionFallBack(archiveDir)
+		archiveDiag := analysis.Diagnostic{
+			Name:     "zip-invalid",
+			Severity: analysis.Error,
+			Title:    "Plugin archive is improperly structured",
+			Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
+		}
+		diags["archive"] = append(diags["archive"], archiveDiag)
 	}
+
+	// Additional JSON output to file
 	if *outputToFile != "" {
+		ob, err := output.NewJSONMarshaler(pluginID, pluginVersion).Marshal(diags)
+		if err != nil {
+			logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
+			os.Exit(1)
+		}
 		if err := os.WriteFile(*outputToFile, ob, 0644); err != nil {
 			logme.Errorln(fmt.Errorf("couldn't write output to file: %w", err))
 		}
+	}
+
+	// Stdout/Stderr output.
+
+	// Determine the correct marshaler depending on the config
+	if cfg.Global.JSONOutput {
+		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
+	} else {
+		outputMarshaler = output.MarshalCLI
 	}
 
 	// Write to stdout or stderr, depending on config
@@ -210,8 +212,13 @@ func main() {
 		outWriter = os.Stderr
 	}
 
-	// Write the output and exit.
+	// Write output with the correct marshaler, depending on the config, then exit.
 	// Nothing else should be printed from here on, or the output may become invalid.
+	ob, err := outputMarshaler.Marshal(diags)
+	if err != nil {
+		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
+		os.Exit(1)
+	}
 	_, _ = fmt.Fprintln(outWriter, string(ob))
 	os.Exit(output.ExitCode(*strictFlag, diags))
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -39,7 +39,7 @@ func Check(
 	params analysis.CheckParams,
 	cfg Config,
 	severityOverwrite analysis.Severity,
-) (map[string][]analysis.Diagnostic, error) {
+) (analysis.Diagnostics, error) {
 	pluginId, err := utils.GetPluginId(params.ArchiveDir)
 	if err != nil {
 		// we only need the pluginId to check for exceptions
@@ -48,7 +48,7 @@ func Check(
 	}
 
 	initAnalyzers(analyzers, &cfg, pluginId, severityOverwrite)
-	diagnostics := make(map[string][]analysis.Diagnostic)
+	diagnostics := make(analysis.Diagnostics)
 
 	pass := &analysis.Pass{
 		RootDir:     params.ArchiveDir,


### PR DESCRIPTION
Refactor of the output system for the CLI program. This allows to easily add output formats. Currently, refactored the existing CLI and JSON outputs to use the newly introduced interface. This is useful to implement output in GitHub Actions format.

Part of https://github.com/grafana/plugin-validator/issues/450