### PR TITLE
feat: add output in GitHub Actions workflow commands format

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -67,6 +67,8 @@ type Diagnostic struct {
 	Name     string
 }
 
+type Diagnostics map[string][]Diagnostic
+
 type Rule struct {
 	Name      string
 	Disabled  bool

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/fatih/color"
+
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
@@ -92,9 +93,9 @@ var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 
 // ExitCode returns the exit code of the CLI program.
 // It returns:
-//   - 1 if there's an error;
-//   - 1 if there's a warning AND strict is true;
-//   - 0 in all other cases.
+// 1 if there's an error;
+// 1 if there's a warning AND strict is true;
+// 0 in all other cases.
 func ExitCode(strict bool, diags analysis.Diagnostics) int {
 	for _, ds := range diags {
 		for _, d := range ds {

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -1,0 +1,98 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/fatih/color"
+	"github.com/grafana/plugin-validator/pkg/analysis"
+)
+
+type Marshaler interface {
+	Marshal(data analysis.Diagnostics) ([]byte, error)
+}
+
+type marshalerFunc func(data analysis.Diagnostics) ([]byte, error)
+
+func (f marshalerFunc) Marshal(data analysis.Diagnostics) ([]byte, error) {
+	return f(data)
+}
+
+type jsonMarshaler struct {
+	id      string
+	version string
+}
+
+func NewJSONMarshaler(id string, version string) Marshaler {
+	return jsonMarshaler{id, version}
+}
+
+type jsonOutput struct {
+	ID          string               `json:"id"`
+	Version     string               `json:"version"`
+	Diagnostics analysis.Diagnostics `json:"plugin-validator"`
+}
+
+func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
+	return json.MarshalIndent(jsonOutput{
+		ID:          j.id,
+		Version:     j.version,
+		Diagnostics: data,
+	}, "", "  ")
+}
+
+var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
+	var buf bytes.Buffer
+	for name := range data {
+		for _, d := range data[name] {
+			switch d.Severity {
+			case analysis.Error:
+				buf.WriteString(color.RedString("error: "))
+			case analysis.Warning:
+				buf.WriteString(color.YellowString("warning: "))
+			case analysis.Recommendation:
+				buf.WriteString(color.CyanString("recommendation: "))
+			case analysis.OK:
+				buf.WriteString(color.GreenString("ok: "))
+			case analysis.SuspectedProblem:
+				buf.WriteString(color.YellowString("suspected: "))
+			}
+
+			if d.Context != "" {
+				buf.WriteString(d.Context + ": ")
+			}
+
+			buf.WriteString(d.Title)
+			if len(d.Detail) > 0 {
+				buf.WriteRune('\n')
+				buf.WriteString(color.BlueString("detail: "))
+				buf.WriteString(d.Detail)
+			}
+			buf.WriteRune('\n')
+		}
+	}
+	return buf.Bytes(), nil
+})
+
+func ExitCode(strict bool, diags analysis.Diagnostics) int {
+	for _, ds := range diags {
+		for _, d := range ds {
+			switch d.Severity {
+			case analysis.Error:
+				return 1
+			case analysis.Warning:
+				if strict {
+					return 1
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Static checks
+
+var (
+	_ = Marshaler(jsonMarshaler{})
+	_ = Marshaler(MarshalCLI)
+)

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -128,7 +128,9 @@ var MarshalGHA = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 				// Add context to the ghaTitle, if we have it
 				diagnosticsTitle = d.Context + ": " + diagnosticsTitle
 			}
-			ghaTitle += ": " + diagnosticsTitle
+			if diagnosticsTitle != "" {
+				ghaTitle += ": " + diagnosticsTitle
+			}
 
 			if d.Detail != "" {
 				// If we have details, use them as the ghaMessage

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -91,6 +91,9 @@ var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	return buf.Bytes(), nil
 })
 
+// MarshalGHA is a Marshaler that returns the diagnostics data in GitHub Actions workflow commands format.
+// See GitHub Actions docs for more information:
+// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-notice-message
 var MarshalGHA = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	var buf bytes.Buffer
 	for name := range data {

--- a/pkg/analysis/output/output.go
+++ b/pkg/analysis/output/output.go
@@ -8,21 +8,34 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis"
 )
 
+// Marshaler is an interface for encoding the analysis results into bytes.
+// Each implementation outputs the analysis results in a different format.
 type Marshaler interface {
+	// Marshal encodes the diagnostics data in the format implemented by the marshaler.
 	Marshal(data analysis.Diagnostics) ([]byte, error)
 }
 
+// marshalerFunc is an adapter for using normal functions as Marshaler.
 type marshalerFunc func(data analysis.Diagnostics) ([]byte, error)
 
+// Marshal marshals the diagnostics data using the function.
 func (f marshalerFunc) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	return f(data)
 }
 
+// jsonMarshaler is a Marshaler that outputs to JSON format.
 type jsonMarshaler struct {
-	id      string
+	// Additional fields used for JSON output
+
+	// id is the plugin ID
+	id string
+
+	// version is the plugin version
 	version string
 }
 
+// NewJSONMarshaler returns a new Marshaler that outputs the diagnostics data in JSON format.
+// This marshaler requires additional plugin id and plugin version arguments.
 func NewJSONMarshaler(id string, version string) Marshaler {
 	return jsonMarshaler{id, version}
 }
@@ -33,6 +46,8 @@ type jsonOutput struct {
 	Diagnostics analysis.Diagnostics `json:"plugin-validator"`
 }
 
+// Marshal marshals the diagnostics data in JSON format.
+// The additional id and version fields are taken from the marshaler itself.
 func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	return json.MarshalIndent(jsonOutput{
 		ID:          j.id,
@@ -41,6 +56,7 @@ func (j jsonMarshaler) Marshal(data analysis.Diagnostics) ([]byte, error) {
 	}, "", "  ")
 }
 
+// MarshalCLI is a Marshaler that returns the diagnostics data in a human-readable format, for CLI usage.
 var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	var buf bytes.Buffer
 	for name := range data {
@@ -74,6 +90,11 @@ var MarshalCLI = marshalerFunc(func(data analysis.Diagnostics) ([]byte, error) {
 	return buf.Bytes(), nil
 })
 
+// ExitCode returns the exit code of the CLI program.
+// It returns:
+//   - 1 if there's an error;
+//   - 1 if there's a warning AND strict is true;
+//   - 0 in all other cases.
 func ExitCode(strict bool, diags analysis.Diagnostics) int {
 	for _, ds := range diags {
 		for _, d := range ds {

--- a/pkg/analysis/output/output_test.go
+++ b/pkg/analysis/output/output_test.go
@@ -1,0 +1,196 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+)
+
+func TestGHAOutput(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		diags analysis.Diagnostics
+		exp   string
+	}{
+		{
+			name: "error with title and details",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.Error,
+						Title:    "Test error",
+						Detail:   "This is a test error detail",
+					},
+				},
+			},
+			exp: "::error title=plugin-validator: Error: Test error::This is a test error detail\n",
+		},
+		{
+			name: "error with title and without details",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.Error,
+						Title:    "Test error",
+					},
+				},
+			},
+			exp: "::error title=plugin-validator: Error::Test error\n",
+		},
+		{
+			name: "error without title and with details",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.Error,
+						Detail:   "This is a test error detail",
+					},
+				},
+			},
+			exp: "::error title=plugin-validator: Error::This is a test error detail\n",
+		},
+		{
+			name: "warning",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.Warning,
+						Title:    "Test warning",
+						Detail:   "This is a test warning detail",
+					},
+				},
+			},
+			exp: "::warning title=plugin-validator: Warning: Test warning::This is a test warning detail\n",
+		},
+		{
+			name: "recommendation",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.Recommendation,
+						Title:    "Test recommendation",
+						Detail:   "This is a test recommendation detail",
+					},
+				},
+			},
+			exp: "::notice title=plugin-validator: Recommendation: Test recommendation::This is a test recommendation detail\n",
+		},
+		{
+			name: "ok debug",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{
+						Name:     "rule1",
+						Severity: analysis.OK,
+						Title:    "Test ok",
+						Detail:   "This is a test ok detail",
+					},
+				},
+			},
+			exp: "::debug::title=plugin-validator: OK: Test ok::This is a test ok detail\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := MarshalGHA(tc.diags)
+			require.NoError(t, err)
+			require.Equal(t, tc.exp, string(out))
+		})
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		diags  analysis.Diagnostics
+		strict bool
+		exp    int
+	}{
+		{name: "empty", diags: analysis.Diagnostics{}, exp: 0},
+		{name: "empty strictr", diags: analysis.Diagnostics{}, strict: true, exp: 0},
+		{
+			name: "only ok",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.OK},
+					{Severity: analysis.OK},
+				},
+			},
+			exp: 0,
+		},
+		{
+			name: "only ok strict",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.OK},
+					{Severity: analysis.OK},
+				},
+			},
+			strict: true,
+			exp:    0,
+		},
+		{
+			name: "only recommendation",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.Recommendation},
+					{Severity: analysis.Recommendation},
+				},
+			},
+			exp: 0,
+		},
+		{
+			name: "only recommendation strict",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.Recommendation},
+					{Severity: analysis.Recommendation},
+				},
+			},
+			strict: true,
+			exp:    0,
+		},
+		{
+			name: "warning present not strict should exit with 0",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.OK},
+					{Severity: analysis.Warning},
+				},
+			},
+			exp: 0,
+		},
+		{
+			name: "warning present strict should exit with 1",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.OK},
+					{Severity: analysis.Warning},
+				},
+			},
+			strict: true,
+			exp:    1,
+		},
+		{
+			name: "error present",
+			diags: analysis.Diagnostics{
+				"analyzer1": {
+					{Severity: analysis.OK},
+					{Severity: analysis.Error},
+				},
+			},
+			exp: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code := ExitCode(tc.strict, tc.diags)
+			require.Equal(t, tc.exp, code)
+		})
+	}
+}

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -170,6 +170,11 @@ func main() {
 
 	var outputMarshaler output.Marshaler
 
+	if cfg.Global.JSONOutput && cfg.Global.GHAOutput {
+		logme.Errorln("can't have more than one output type set to true")
+		os.Exit(1)
+	}
+
 	if *outputToFile != "" || cfg.Global.JSONOutput {
 		// JSON output for either JSON CLI or JSON file
 		pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
@@ -184,11 +189,13 @@ func main() {
 			diags["archive"] = append(diags["archive"], archiveDiag)
 		}
 		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
+	} else if cfg.Global.GHAOutput {
+		// GHA output
+		outputMarshaler = output.MarshalGHA
 	} else {
 		// CLI output
 		outputMarshaler = output.MarshalCLI
 	}
-	// TODO: gha output
 
 	// Marshal output with the correct marshaler, depending on the config
 	ob, err := outputMarshaler.Marshal(diags)

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/grafana/plugin-validator/pkg/analysis/output"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/output"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes"
 	"github.com/grafana/plugin-validator/pkg/archivetool"
 	"github.com/grafana/plugin-validator/pkg/logme"

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -219,7 +219,10 @@ func main() {
 		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
 		os.Exit(1)
 	}
-	_, _ = fmt.Fprintln(outWriter, string(ob))
+	if _, err = fmt.Fprintln(outWriter, string(ob)); err != nil {
+		logme.Errorln(fmt.Errorf("couldn't write output: %w", err))
+		os.Exit(1)
+	}
 	os.Exit(output.ExitCode(*strictFlag, diags))
 }
 

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -170,36 +170,38 @@ func main() {
 
 	var outputMarshaler output.Marshaler
 
-	if *outputToFile != "" || cfg.Global.JSONOutput {
-		// JSON output for either JSON CLI or JSON file
-		pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
-		if err != nil {
-			pluginID, pluginVersion = GetIDAndVersionFallBack(archiveDir)
-			archiveDiag := analysis.Diagnostic{
-				Name:     "zip-invalid",
-				Severity: analysis.Error,
-				Title:    "Plugin archive is improperly structured",
-				Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
-			}
-			diags["archive"] = append(diags["archive"], archiveDiag)
-		}
-		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
-	} else {
-		// CLI output
-		outputMarshaler = output.MarshalCLI
-	}
-	// TODO: gha output
-
-	// Marshal output with the correct marshaler, depending on the config
-	ob, err := outputMarshaler.Marshal(diags)
+	// Plugin ID and version (needed by JSON output)
+	pluginID, pluginVersion, err := GetIDAndVersion(archiveDir)
 	if err != nil {
-		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
-		os.Exit(1)
+		pluginID, pluginVersion = GetIDAndVersionFallBack(archiveDir)
+		archiveDiag := analysis.Diagnostic{
+			Name:     "zip-invalid",
+			Severity: analysis.Error,
+			Title:    "Plugin archive is improperly structured",
+			Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
+		}
+		diags["archive"] = append(diags["archive"], archiveDiag)
 	}
+
+	// Additional JSON output to file
 	if *outputToFile != "" {
+		ob, err := output.NewJSONMarshaler(pluginID, pluginVersion).Marshal(diags)
+		if err != nil {
+			logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
+			os.Exit(1)
+		}
 		if err := os.WriteFile(*outputToFile, ob, 0644); err != nil {
 			logme.Errorln(fmt.Errorf("couldn't write output to file: %w", err))
 		}
+	}
+
+	// Stdout/Stderr output.
+
+	// Determine the correct marshaler depending on the config
+	if cfg.Global.JSONOutput {
+		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
+	} else {
+		outputMarshaler = output.MarshalCLI
 	}
 
 	// Write to stdout or stderr, depending on config
@@ -210,8 +212,13 @@ func main() {
 		outWriter = os.Stderr
 	}
 
-	// Write the output and exit.
+	// Write output with the correct marshaler, depending on the config, then exit.
 	// Nothing else should be printed from here on, or the output may become invalid.
+	ob, err := outputMarshaler.Marshal(diags)
+	if err != nil {
+		logme.Errorln(fmt.Errorf("couldn't marshal output: %w", err))
+		os.Exit(1)
+	}
 	_, _ = fmt.Fprintln(outWriter, string(ob))
 	os.Exit(output.ExitCode(*strictFlag, diags))
 }

--- a/pkg/cmd/plugincheck2/main.go
+++ b/pkg/cmd/plugincheck2/main.go
@@ -197,9 +197,17 @@ func main() {
 
 	// Stdout/Stderr output.
 
+	// Check that the config is valid
+	if cfg.Global.JSONOutput && cfg.Global.GHAOutput {
+		logme.Errorln("can't have more than one output type set to true")
+		os.Exit(1)
+	}
+
 	// Determine the correct marshaler depending on the config
 	if cfg.Global.JSONOutput {
 		outputMarshaler = output.NewJSONMarshaler(pluginID, pluginVersion)
+	} else if cfg.Global.GHAOutput {
+		outputMarshaler = output.MarshalGHA
 	} else {
 		outputMarshaler = output.MarshalCLI
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -17,6 +17,7 @@ type GlobalConfig struct {
 	Enabled    bool              `yaml:"enabled"`
 	Severity   analysis.Severity `yaml:"severity"`
 	JSONOutput bool              `yaml:"jsonOutput"`
+	GHAOutput  bool              `yaml:"ghaOutput"`
 	ReportAll  bool              `yaml:"reportAll"`
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -39,7 +39,7 @@ func Check(
 	params analysis.CheckParams,
 	cfg Config,
 	severityOverwrite analysis.Severity,
-) (map[string][]analysis.Diagnostic, error) {
+) (analysis.Diagnostics, error) {
 	pluginId, err := utils.GetPluginId(params.ArchiveDir)
 	if err != nil {
 		// we only need the pluginId to check for exceptions
@@ -48,7 +48,7 @@ func Check(
 	}
 
 	initAnalyzers(analyzers, &cfg, pluginId, severityOverwrite)
-	diagnostics := make(map[string][]analysis.Diagnostic)
+	diagnostics := make(analysis.Diagnostics)
 
 	pass := &analysis.Pass{
 		RootDir:     params.ArchiveDir,


### PR DESCRIPTION
Adds an additional `ghaOutput` bool flag in the config file, which will output to stderr in GHA workflow commands (annotations) format.

Example of how this looks like in GHA can be seen in this run: https://github.com/grafana/plugins-drone-to-gha/actions/runs/19097634524

<img width="1126" height="521" alt="immagine" src="https://github.com/user-attachments/assets/1a4a073f-2917-4588-959b-5352e4c58533" />


Part of #450 

Requires #451 