### PR TITLE
ci: switch to self-hosted runners

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on: # zizmor: ignore[cache-poisoning]
 
 jobs:
   release-to-github:
-    runs-on: ubuntu-arm64-large
+    runs-on: ubuntu-arm64
     permissions:
       contents: read
       id-token: write
@@ -66,7 +66,7 @@ jobs:
       - run: npm publish
 
   release-to-dockerhub:
-    runs-on: ubuntu-x64-large
+    runs-on: ubuntu-x64
     # this job doesn't really need the github release, but it is a fast
     # way to prevent it from running if the release is bad
     needs: release-to-github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on: # zizmor: ignore[cache-poisoning]
 
 jobs:
   release-to-github:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-large
     permissions:
       contents: read
       id-token: write
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   release-to-npm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     needs: release-to-github
     permissions:
       contents: read
@@ -66,7 +66,7 @@ jobs:
       - run: npm publish
 
   release-to-dockerhub:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     # this job doesn't really need the github release, but it is a fast
     # way to prevent it from running if the release is bad
     needs: release-to-github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-docker-build:
-    runs-on: ubuntu-x64-large
+    runs-on: ubuntu-x64
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Switches github actions runners to self-hosted for all workflows.
