### PR TITLE
chore: address goreleaser deprecation notices

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,15 +19,15 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - format: tar.gz
+  - formats: [ tar.gz ]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ zip ]
 
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Updates the goreleaser config file to address deprecation notices

```
    • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
    • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```

For example see: https://github.com/grafana/plugin-validator/actions/runs/19131963065/job/54674667842#step:8:25

Docs for deprecation notices:

- https://goreleaser.com/deprecations/#snapshotname_template
- https://goreleaser.com/deprecations/#archivesformat
- https://goreleaser.com/deprecations/#archivesformat_overridesformat