### PR TITLE
fix(ci): use github hosted runners for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   release-to-npm:
-    runs-on: ubuntu-arm64-small
+    runs-on: ubuntu-latest
     needs: release-to-github
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up to https://github.com/grafana/plugin-validator/pull/456

Revert to GitHub-hosted runners for npm publish step. It requires provenance attestation, and it's not supported in GitHub-hosted runners.

See here for details: https://github.com/grafana/plugin-validator/actions/runs/19131963065/job/54675549460#step:6:36