### PR TITLE
Remove plugin dependency version from plugin.json schema

### DIFF
--- a/config/plugin.schema.json
+++ b/config/plugin.schema.json
@@ -179,7 +179,7 @@
           "items": {
             "type": "object",
             "description": "Plugin dependency. Used to display information about plugin dependencies in the Grafana UI.",
-            "required": ["id", "name", "type", "version"],
+            "required": ["id", "name", "type"],
             "properties": {
               "id": {
                 "type": "string",
@@ -190,9 +190,6 @@
                 "enum": ["app", "datasource", "panel", "secretsmanager"]
               },
               "name": {
-                "type": "string"
-              },
-              "version": {
                 "type": "string"
               }
             }

--- a/pkg/analysis/passes/circulardependencies/circulardependencies.go
+++ b/pkg/analysis/passes/circulardependencies/circulardependencies.go
@@ -69,14 +69,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			} else {
 				// The dependency is not a nested plugin, get the dependencies from GCOM
 				var err error
-				version := dep.Version
-				if version == "" {
-					version = "latest"
-				}
-				dependantDependencies, err = getGCOMPluginDependencies(ctx, dep.ID, version)
+				dependantDependencies, err = getGCOMPluginDependencies(ctx, dep.ID, "latest")
 				if err != nil {
 					// Do not fail the analysis if we cannot get the dependencies from GCOM.
-					logme.ErrorF("Could not get plugin version dependency from gcom: id=%q version=%q: %v\n", dep.ID, version, err)
+					logme.ErrorF("Could not get plugin dependency from gcom: id=%q: %v\n", dep.ID, err)
 
 					dependantDependencies = nil
 					continue

--- a/pkg/analysis/passes/circulardependencies/testdata/external-with-version/grafana-clock-panel/plugin.json
+++ b/pkg/analysis/passes/circulardependencies/testdata/external-with-version/grafana-clock-panel/plugin.json
@@ -5,8 +5,7 @@
       {
         "id": "grafana-external-panel",
         "name": "External",
-        "type": "panel",
-        "version": "2.1.2"
+        "type": "panel"
       }
     ]
   },

--- a/pkg/analysis/passes/metadata/types.go
+++ b/pkg/analysis/passes/metadata/types.go
@@ -60,8 +60,7 @@ type MetadataDependencies struct {
 }
 
 type MetadataPluginDependency struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Version string `json:"version"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }


### PR DESCRIPTION
This has been deprecated for some time but was missed updating when the [schema in grafana/grafana](https://github.com/grafana/grafana/blob/main/docs/sources/developers/plugins/plugin.schema.json) was updated.