### PR TITLE
runner: allow to create plugin-specific exceptions at rule level

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,35 @@ Severity levels could be: `error`, `warning`, or `ok`.
 
 > Note: Grafana Labs enforces its own configuration for plugins submissions and your own config file can't change these rules.
 
+#### Excluding a plugin from an analyzer or rule
+
+It's also possible to exclude a specific plugin from an analyzer or a specific rule within an analyzer. This is useful when a particular check is not applicable to your plugin.
+
+To disable an entire analyzer for a plugin, add an `exceptions` list with the plugin ID.
+
+```yaml
+analyzers:
+  some-analyzer:
+    enabled: true
+    # This entire analyzer will be skipped for 'my-plugin-id'
+    exceptions:
+      - my-plugin-id
+```
+
+To disable a single rule for a plugin, add the `exceptions` list to the rule's configuration.
+
+```yaml
+analyzers:
+  some-analyzer:
+    rules:
+      some-rule:
+        enabled: true
+        # This rule will be skipped for 'my-plugin-id'
+        exceptions:
+          - my-plugin-id
+```
+
+
 ### Source code
 
 You can specify the location of the plugin source code to the validator with the `-sourceCodeUri` option. Doing so allows for additional [analyzers](#analyzers) to be run and for a more complete scan.

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -20,7 +20,7 @@ type Pass struct {
 	AnalyzerName string
 	RootDir      string
 	CheckParams  CheckParams
-	ResultOf     map[*Analyzer]interface{}
+	ResultOf     map[*Analyzer]any
 	Report       func(string, Diagnostic)
 }
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/logme"
@@ -62,15 +63,13 @@ func Check(
 		// Check for exceptions at the rule level
 		if analyzerConfig, ok := cfg.Analyzers[pass.AnalyzerName]; ok {
 			if ruleConfig, ok := analyzerConfig.Rules[ruleName]; ok {
-				for _, exceptedPluginID := range ruleConfig.Exceptions {
-					if exceptedPluginID == pluginId {
-						logme.DebugFln(
-							"Diagnostic for rule '%s' skipped for plugin '%s' due to a rule-level exception.",
-							ruleName,
-							pluginId,
-						)
-						return
-					}
+				if slices.Contains(ruleConfig.Exceptions, pluginId) {
+					logme.DebugFln(
+						"Diagnostic for rule '%s' skipped for plugin '%s' due to a rule-level exception.",
+						ruleName,
+						pluginId,
+					)
+					return
 				}
 			}
 		}
@@ -186,10 +185,8 @@ func initAnalyzers(
 
 func isExcepted(pluginId string, cfg *AnalyzerConfig) bool {
 	if len(pluginId) > 0 && cfg != nil && len(cfg.Exceptions) > 0 {
-		for _, exception := range cfg.Exceptions {
-			if exception == pluginId {
-				return true
-			}
+		if slices.Contains(cfg.Exceptions, pluginId) {
+			return true
 		}
 	}
 	return false

--- a/pkg/runner/testdata/RuleExceptions/myorg-plugin-panel/plugin.json
+++ b/pkg/runner/testdata/RuleExceptions/myorg-plugin-panel/plugin.json
@@ -1,0 +1,5 @@
+{
+  "id": "myorg-plugin-panel",
+  "name": "my-plugin",
+  "type": "panel"
+}


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-validator/issues/457

This PR allows to configure exceptions for specific rules for specific plugins id

This feature is a complement to the existing exceptions at a validator level but with better granularity

e.g. you want the coderules analyzer to run but only ignore specific rules for your plugin
