### PR TITLE
runner: allow validators to access other's validators diagnostics

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -22,8 +22,7 @@ type Pass struct {
 	CheckParams      CheckParams
 	ResultOf         map[*Analyzer]any
 	Report           func(string, Diagnostic)
-	Diagnostics      *Diagnostics
-	AnalyzerRulesMap map[string]string
+	Diagnostics *Diagnostics
 }
 
 type CheckParams struct {
@@ -67,10 +66,8 @@ func (p *Pass) GetAnalyzerDiagnostics(a *Analyzer) []Diagnostic {
 		return nil
 	}
 	var result []Diagnostic
-	for key, diags := range *p.Diagnostics {
-		// Key is the analyzer name when using ReportResult (which all validators use)
-		// or a rule name when using Report directly (mainly in tests)
-		if key == a.Name || p.AnalyzerRulesMap[key] == a.Name {
+	for analyzerName, diags := range *p.Diagnostics {
+		if analyzerName == a.Name {
 			result = append(result, diags...)
 		}
 	}

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -22,7 +22,7 @@ type Pass struct {
 	CheckParams      CheckParams
 	ResultOf         map[*Analyzer]any
 	Report           func(string, Diagnostic)
-	Diagnostics *Diagnostics
+	Diagnostics      *Diagnostics
 }
 
 type CheckParams struct {

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -17,11 +17,13 @@ var (
 )
 
 type Pass struct {
-	AnalyzerName string
-	RootDir      string
-	CheckParams  CheckParams
-	ResultOf     map[*Analyzer]any
-	Report       func(string, Diagnostic)
+	AnalyzerName     string
+	RootDir          string
+	CheckParams      CheckParams
+	ResultOf         map[*Analyzer]any
+	Report           func(string, Diagnostic)
+	Diagnostics      *Diagnostics
+	AnalyzerRulesMap map[string]string
 }
 
 type CheckParams struct {
@@ -57,6 +59,22 @@ func (p *Pass) ReportResult(analysisName string, rule *Rule, message string, det
 		Title:    message,
 		Detail:   detail,
 	})
+}
+
+// GetAnalyzerDiagnostics returns all diagnostics reported by the given analyzer.
+func (p *Pass) GetAnalyzerDiagnostics(a *Analyzer) []Diagnostic {
+	if p.Diagnostics == nil || a == nil {
+		return nil
+	}
+	var result []Diagnostic
+	for key, diags := range *p.Diagnostics {
+		// Key is the analyzer name when using ReportResult (which all validators use)
+		// or a rule name when using Report directly (mainly in tests)
+		if key == a.Name || p.AnalyzerRulesMap[key] == a.Name {
+			result = append(result, diags...)
+		}
+	}
+	return result
 }
 
 type Diagnostic struct {

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -77,6 +77,16 @@ func (p *Pass) GetAnalyzerDiagnostics(a *Analyzer) []Diagnostic {
 	return result
 }
 
+// AnalyzerHasErrors returns true if the given analyzer reported any diagnostics with Error severity.
+func (p *Pass) AnalyzerHasErrors(a *Analyzer) bool {
+	for _, d := range p.GetAnalyzerDiagnostics(a) {
+		if d.Severity == Error {
+			return true
+		}
+	}
+	return false
+}
+
 type Diagnostic struct {
 	Severity Severity
 	Title    string

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -60,14 +60,14 @@ func Check(
 		Diagnostics: &diagnostics,
 	}
 
-	pass.Report = func(ruleName string, d analysis.Diagnostic) {
+	pass.Report = func(analyzerName string, d analysis.Diagnostic) {
 		// Check for exceptions at the rule level
 		if analyzerConfig, ok := cfg.Analyzers[pass.AnalyzerName]; ok {
-			if ruleConfig, ok := analyzerConfig.Rules[ruleName]; ok {
+			if ruleConfig, ok := analyzerConfig.Rules[analyzerName]; ok {
 				if slices.Contains(ruleConfig.Exceptions, pluginId) {
 					logme.DebugFln(
 						"Diagnostic for rule '%s' skipped for plugin '%s' due to a rule-level exception.",
-						ruleName,
+						analyzerName,
 						pluginId,
 					)
 					return
@@ -75,7 +75,7 @@ func Check(
 			}
 		}
 		// Collect all diagnostics for presenting at the end.
-		diagnostics[ruleName] = append(diagnostics[ruleName], d)
+		diagnostics[analyzerName] = append(diagnostics[analyzerName], d)
 	}
 
 	seen := make(map[*analysis.Analyzer]bool)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -57,6 +57,7 @@ func Check(
 		RootDir:     params.ArchiveDir,
 		CheckParams: params,
 		ResultOf:    make(map[*analysis.Analyzer]any),
+		Diagnostics: &diagnostics,
 		Report: func(analyzerName string, d analysis.Diagnostic) {
 			diagnostics[analyzerName] = append(diagnostics[analyzerName], d)
 		},

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -53,32 +53,11 @@ func Check(
 	initAnalyzers(analyzers, &cfg, pluginId, severityOverwrite)
 	diagnostics := make(analysis.Diagnostics)
 
-	// Build rule name to analyzer name lookup map (including dependencies)
-	analyzerRulesMap := make(map[string]string)
-	seenAnalyzers := make(map[*analysis.Analyzer]bool)
-	var collectRules func(a *analysis.Analyzer)
-	collectRules = func(a *analysis.Analyzer) {
-		if seenAnalyzers[a] {
-			return
-		}
-		seenAnalyzers[a] = true
-		for _, r := range a.Rules {
-			analyzerRulesMap[r.Name] = a.Name
-		}
-		for _, dep := range a.Requires {
-			collectRules(dep)
-		}
-	}
-	for _, a := range analyzers {
-		collectRules(a)
-	}
-
 	pass := &analysis.Pass{
-		RootDir:          params.ArchiveDir,
-		CheckParams:      params,
-		ResultOf:         make(map[*analysis.Analyzer]any),
-		Diagnostics:      &diagnostics,
-		AnalyzerRulesMap: analyzerRulesMap,
+		RootDir:     params.ArchiveDir,
+		CheckParams: params,
+		ResultOf:    make(map[*analysis.Analyzer]any),
+		Diagnostics: &diagnostics,
 	}
 
 	pass.Report = func(ruleName string, d analysis.Diagnostic) {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -357,7 +357,12 @@ func TestGetAnalyzerDiagnostics(t *testing.T) {
 		Run: func(pass *analysis.Pass) (interface{}, error) {
 			// Child can read parent's diagnostics
 			parentDiagnostics := pass.GetAnalyzerDiagnostics(parentAnalyzer)
-			assert.Len(t, parentDiagnostics, 1, "child should see exactly one diagnostic from parent")
+			assert.Len(
+				t,
+				parentDiagnostics,
+				1,
+				"child should see exactly one diagnostic from parent",
+			)
 			assert.Equal(t, "parent error", parentDiagnostics[0].Title)
 			assert.Equal(t, "parent detail", parentDiagnostics[0].Detail)
 			assert.Equal(t, analysis.Error, parentDiagnostics[0].Severity)
@@ -397,7 +402,11 @@ func TestGetAnalyzerDiagnosticsEmpty(t *testing.T) {
 		Requires: []*analysis.Analyzer{parentAnalyzer},
 		Run: func(pass *analysis.Pass) (interface{}, error) {
 			parentDiagnostics := pass.GetAnalyzerDiagnostics(parentAnalyzer)
-			assert.Empty(t, parentDiagnostics, "should return empty slice when analyzer reported nothing")
+			assert.Empty(
+				t,
+				parentDiagnostics,
+				"should return empty slice when analyzer reported nothing",
+			)
 			return nil, nil
 		},
 	}
@@ -530,7 +539,11 @@ func TestAnalyzerHasErrors(t *testing.T) {
 		Requires: []*analysis.Analyzer{analyzerWithErrors, analyzerWithWarningsOnly},
 		Run: func(pass *analysis.Pass) (interface{}, error) {
 			assert.True(t, pass.AnalyzerHasErrors(analyzerWithErrors), "should detect errors")
-			assert.False(t, pass.AnalyzerHasErrors(analyzerWithWarningsOnly), "should not report errors for warnings-only")
+			assert.False(
+				t,
+				pass.AnalyzerHasErrors(analyzerWithWarningsOnly),
+				"should not report errors for warnings-only",
+			)
 			return nil, nil
 		},
 	}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -336,3 +336,168 @@ func TestDependencyReturnsNil(t *testing.T) {
 
 	assert.Len(t, res, 2)
 }
+
+func TestGetAnalyzerDiagnostics(t *testing.T) {
+	parentRule := &analysis.Rule{Name: "parent-rule", Severity: analysis.Error}
+	childRule := &analysis.Rule{Name: "child-rule", Severity: analysis.Warning}
+
+	parentAnalyzer := &analysis.Analyzer{
+		Name:  "parent-analyzer",
+		Rules: []*analysis.Rule{parentRule},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			pass.ReportResult(pass.AnalyzerName, parentRule, "parent error", "parent detail")
+			return nil, nil
+		},
+	}
+
+	childAnalyzer := &analysis.Analyzer{
+		Name:     "child-analyzer",
+		Requires: []*analysis.Analyzer{parentAnalyzer},
+		Rules:    []*analysis.Rule{childRule},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			// Child can read parent's diagnostics
+			parentDiagnostics := pass.GetAnalyzerDiagnostics(parentAnalyzer)
+			assert.Len(t, parentDiagnostics, 1, "child should see exactly one diagnostic from parent")
+			assert.Equal(t, "parent error", parentDiagnostics[0].Title)
+			assert.Equal(t, "parent detail", parentDiagnostics[0].Detail)
+			assert.Equal(t, analysis.Error, parentDiagnostics[0].Severity)
+
+			pass.ReportResult(pass.AnalyzerName, childRule, "child warning", "child detail")
+			return nil, nil
+		},
+	}
+
+	diagnostics, err := Check(
+		[]*analysis.Analyzer{childAnalyzer},
+		analysis.CheckParams{},
+		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
+	)
+
+	assert.NoError(t, err)
+	assert.Len(t, diagnostics, 2)
+	assert.Contains(t, diagnostics, "parent-analyzer")
+	assert.Contains(t, diagnostics, "child-analyzer")
+}
+
+func TestGetAnalyzerDiagnosticsEmpty(t *testing.T) {
+	parentRule := &analysis.Rule{Name: "parent-rule", Severity: analysis.Error}
+
+	parentAnalyzer := &analysis.Analyzer{
+		Name:  "parent-analyzer",
+		Rules: []*analysis.Rule{parentRule},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			// Parent reports nothing
+			return nil, nil
+		},
+	}
+
+	childAnalyzer := &analysis.Analyzer{
+		Name:     "child-analyzer",
+		Requires: []*analysis.Analyzer{parentAnalyzer},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			parentDiagnostics := pass.GetAnalyzerDiagnostics(parentAnalyzer)
+			assert.Empty(t, parentDiagnostics, "should return empty slice when analyzer reported nothing")
+			return nil, nil
+		},
+	}
+
+	_, err := Check(
+		[]*analysis.Analyzer{childAnalyzer},
+		analysis.CheckParams{},
+		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
+	)
+
+	assert.NoError(t, err)
+}
+
+func TestGetAnalyzerDiagnosticsMultipleRules(t *testing.T) {
+	rule1 := &analysis.Rule{Name: "rule1", Severity: analysis.Error}
+	rule2 := &analysis.Rule{Name: "rule2", Severity: analysis.Warning}
+	otherRule := &analysis.Rule{Name: "other-rule", Severity: analysis.Error}
+
+	analyzer1 := &analysis.Analyzer{
+		Name:  "analyzer1",
+		Rules: []*analysis.Rule{rule1, rule2},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			pass.ReportResult(pass.AnalyzerName, rule1, "error from analyzer1", "")
+			pass.ReportResult(pass.AnalyzerName, rule2, "warning from analyzer1", "")
+			return nil, nil
+		},
+	}
+
+	analyzer2 := &analysis.Analyzer{
+		Name:  "analyzer2",
+		Rules: []*analysis.Rule{otherRule},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			pass.ReportResult(pass.AnalyzerName, otherRule, "error from analyzer2", "")
+			return nil, nil
+		},
+	}
+
+	reader := &analysis.Analyzer{
+		Name:     "reader",
+		Requires: []*analysis.Analyzer{analyzer1, analyzer2},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			analyzer1Diagnostics := pass.GetAnalyzerDiagnostics(analyzer1)
+			analyzer2Diagnostics := pass.GetAnalyzerDiagnostics(analyzer2)
+
+			assert.Len(t, analyzer1Diagnostics, 2, "should get all diagnostics from analyzer1")
+			assert.Len(t, analyzer2Diagnostics, 1, "should get only diagnostics from analyzer2")
+			assert.Equal(t, "error from analyzer2", analyzer2Diagnostics[0].Title)
+			return nil, nil
+		},
+	}
+
+	_, err := Check(
+		[]*analysis.Analyzer{reader},
+		analysis.CheckParams{},
+		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
+	)
+
+	assert.NoError(t, err)
+}
+
+func TestGetAnalyzerDiagnosticsCheckForErrors(t *testing.T) {
+	errorRule := &analysis.Rule{Name: "error-rule", Severity: analysis.Error}
+	warningRule := &analysis.Rule{Name: "warning-rule", Severity: analysis.Warning}
+
+	parentAnalyzer := &analysis.Analyzer{
+		Name:  "parent-analyzer",
+		Rules: []*analysis.Rule{errorRule, warningRule},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			pass.ReportResult(pass.AnalyzerName, errorRule, "this is an error", "")
+			pass.ReportResult(pass.AnalyzerName, warningRule, "this is a warning", "")
+			return nil, nil
+		},
+	}
+
+	childAnalyzer := &analysis.Analyzer{
+		Name:     "child-analyzer",
+		Requires: []*analysis.Analyzer{parentAnalyzer},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			// Check if parent reported any errors
+			parentDiagnostics := pass.GetAnalyzerDiagnostics(parentAnalyzer)
+			hasErrors := false
+			for _, d := range parentDiagnostics {
+				if d.Severity == analysis.Error {
+					hasErrors = true
+					break
+				}
+			}
+			assert.True(t, hasErrors, "child should detect that parent reported errors")
+			return nil, nil
+		},
+	}
+
+	_, err := Check(
+		[]*analysis.Analyzer{childAnalyzer},
+		analysis.CheckParams{},
+		Config{Global: GlobalConfig{Enabled: true}},
+		analysis.Severity(""),
+	)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adds infrastructure for validators to access diagnostics reported by other validators. This enables expensive validators (LLMReview, CodeDiff) to skip execution when dependencies already reported errors.

Example of Usage

 ```go
   func run(pass *analysis.Pass) (interface{}, error) {
       if pass.AnalyzerHasErrors(sourcecode.Analyzer) {
           // Skip expensive LLM call
           return nil, nil
       }
       // proceed...
   }
 ```

 Notes

 - Does not modify existing validators yet - this PR only adds the infrastructure

 Closes #494
