### PR TITLE
runner: fix incorrect rule exceptions logic from previous implementation

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -57,24 +57,9 @@ func Check(
 		RootDir:     params.ArchiveDir,
 		CheckParams: params,
 		ResultOf:    make(map[*analysis.Analyzer]any),
-	}
-
-	pass.Report = func(ruleName string, d analysis.Diagnostic) {
-		// Check for exceptions at the rule level
-		if analyzerConfig, ok := cfg.Analyzers[pass.AnalyzerName]; ok {
-			if ruleConfig, ok := analyzerConfig.Rules[ruleName]; ok {
-				if slices.Contains(ruleConfig.Exceptions, pluginId) {
-					logme.DebugFln(
-						"Diagnostic for rule '%s' skipped for plugin '%s' due to a rule-level exception.",
-						ruleName,
-						pluginId,
-					)
-					return
-				}
-			}
-		}
-		// Collect all diagnostics for presenting at the end.
-		diagnostics[ruleName] = append(diagnostics[ruleName], d)
+		Report: func(analyzerName string, d analysis.Diagnostic) {
+			diagnostics[analyzerName] = append(diagnostics[analyzerName], d)
+		},
 	}
 
 	seen := make(map[*analysis.Analyzer]bool)
@@ -169,6 +154,15 @@ func initAnalyzers(
 				}
 				if ruleConfig.Severity != nil {
 					ruleSeverity = *ruleConfig.Severity
+				}
+				// Check for rule-level exceptions
+				if slices.Contains(ruleConfig.Exceptions, pluginId) {
+					logme.DebugFln(
+						"Rule '%s' disabled for plugin '%s' due to a rule-level exception.",
+						currentRule.Name,
+						pluginId,
+					)
+					ruleEnabled = false
 				}
 			}
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -112,19 +112,18 @@ func contains(strs []string, str string) bool {
 }
 
 func TestRuleExceptions(t *testing.T) {
+	rule1 := &analysis.Rule{Name: "rule1"}
+	rule2 := &analysis.Rule{Name: "rule2"}
+
 	analyzer := &analysis.Analyzer{
 		Name: "testanalyzer",
 		Rules: []*analysis.Rule{
-			{Name: "rule1"},
-			{Name: "rule2"},
+			rule1,
+			rule2,
 		},
 		Run: func(pass *analysis.Pass) (interface{}, error) {
-			pass.Report("rule1", analysis.Diagnostic{
-				Title: "diagnostic from rule1",
-			})
-			pass.Report("rule2", analysis.Diagnostic{
-				Title: "diagnostic from rule2",
-			})
+			pass.ReportResult(pass.AnalyzerName, rule1, "diagnostic from rule1", "")
+			pass.ReportResult(pass.AnalyzerName, rule2, "diagnostic from rule2", "")
 			return nil, nil
 		},
 	}


### PR DESCRIPTION
[the implementation of this functionality](https://github.com/grafana/plugin-validator/pull/496) was incorrectly using the analyzer name instead of the rule name as the key to create an exception. The tests were created using the analyzer name as the rule key and that is why they didn't catch this early on. 
