### PR TITLE
llm-review: do not run when specific validators generated errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Run "mage gen:readme" to regenerate this section.
 | Sponsorship Link / `sponsorshiplink` | Checks if a sponsorship link is specified in `plugin.json` that will be shown in the Grafana plugin catalog for users to support the plugin developer. | None |
 | Type Suffix (panel/app/datasource) / `typesuffix` | Ensures the plugin has a valid type specified. | None |
 | Unique README.md / `templatereadme` | Ensures the plugin doesn't re-use the template from the `create-plugin` tool. | None |
-| Unsafe SVG / `manifest` | Checks if any svg files are safe based on a whitelist of elements and attributes. | None |
+| Unsafe SVG / `unsafesvg` | Checks if any svg files are safe based on a whitelist of elements and attributes. | None |
 | Version / `version` | Ensures the version submitted is newer than the currently published plugin. If this is a new/unpublished plugin, this is skipped. | None |
 | Virus Scan / `virusscan` | Runs a virus scan on the plugin archive and source code using `clamscan` (`clamav`). | clamscan |
 | Vulnerability Scanner / `osv-scanner` | Detects critical vulnerabilities in Go modules and yarn lock files. | [osv-scanner](https://github.com/google/osv-scanner), `sourceCodeUri` |

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -62,9 +62,26 @@ var blockingAnalyzers = []*analysis.Analyzer{
 }
 
 var Analyzer = &analysis.Analyzer{
-	Name:     "llmreview",
-	Requires: []*analysis.Analyzer{sourcecode.Analyzer},
-	Run:      run,
+	Name: "llmreview",
+	Requires: []*analysis.Analyzer{
+		sourcecode.Analyzer,
+		// Blocking analyzers - if any report errors, LLM review is skipped
+		archive.Analyzer,
+		metadata.Analyzer,
+		metadatavalid.Analyzer,
+		modulejs.Analyzer,
+		coderules.Analyzer,
+		trackingscripts.Analyzer,
+		virusscan.Analyzer,
+		safelinks.Analyzer,
+		unsafesvg.Analyzer,
+		osvscanner.Analyzer,
+		gomanifest.Analyzer,
+		binarypermissions.Analyzer,
+		backendbinary.Analyzer,
+		manifest.Analyzer,
+	},
+	Run: run,
 	Rules:    []*analysis.Rule{llmIssueFound, llmReviewSkipped},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "LLM Review",

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/binarypermissions"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/coderules"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/gomanifest"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/jssourcemap"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/manifest"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadatavalid"
@@ -56,32 +57,16 @@ var blockingAnalyzers = []*analysis.Analyzer{
 	osvscanner.Analyzer,
 	// Tier 3: Build/Integrity issues
 	gomanifest.Analyzer,
+	jssourcemap.Analyzer,
 	binarypermissions.Analyzer,
 	backendbinary.Analyzer,
 	manifest.Analyzer,
 }
 
 var Analyzer = &analysis.Analyzer{
-	Name: "llmreview",
-	Requires: []*analysis.Analyzer{
-		sourcecode.Analyzer,
-		// Blocking analyzers - if any report errors, LLM review is skipped
-		archive.Analyzer,
-		metadata.Analyzer,
-		metadatavalid.Analyzer,
-		modulejs.Analyzer,
-		coderules.Analyzer,
-		trackingscripts.Analyzer,
-		virusscan.Analyzer,
-		safelinks.Analyzer,
-		unsafesvg.Analyzer,
-		osvscanner.Analyzer,
-		gomanifest.Analyzer,
-		binarypermissions.Analyzer,
-		backendbinary.Analyzer,
-		manifest.Analyzer,
-	},
-	Run: run,
+	Name:     "llmreview",
+	Requires: append([]*analysis.Analyzer{sourcecode.Analyzer}, blockingAnalyzers...),
+	Run:      run,
 	Rules:    []*analysis.Rule{llmIssueFound, llmReviewSkipped},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "LLM Review",

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -7,7 +7,21 @@ import (
 	"strings"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/backendbinary"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/binarypermissions"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/coderules"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/gomanifest"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/manifest"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadatavalid"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/osvscanner"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/safelinks"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/trackingscripts"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/virusscan"
 	"github.com/grafana/plugin-validator/pkg/llmvalidate"
 	"github.com/grafana/plugin-validator/pkg/logme"
 )
@@ -15,14 +29,43 @@ import (
 var geminiKey = os.Getenv("GEMINI_API_KEY")
 
 var (
-	llmIssueFound = &analysis.Rule{Name: "llm-issue-found", Severity: analysis.SuspectedProblem}
+	llmIssueFound    = &analysis.Rule{Name: "llm-issue-found", Severity: analysis.SuspectedProblem}
+	llmReviewSkipped = &analysis.Rule{
+		Name:     "llm-review-skipped",
+		Severity: analysis.SuspectedProblem,
+	}
 )
+
+// blockingAnalyzers contains validators that, if they report errors, should cause
+// the LLM review to be skipped to save costs. These are grouped into:
+// - Tier 1 (Structure): archive, metadata, metadatavalid, modulejs
+// - Tier 2 (Security): coderules, trackingscripts, virusscan, safelinks, unsafesvg, osvscanner
+// - Tier 3 (Integrity): gomanifest, binarypermissions, backendbinary, manifest
+var blockingAnalyzers = []*analysis.Analyzer{
+	// Tier 1: Fundamental structure issues
+	archive.Analyzer,
+	metadata.Analyzer,
+	metadatavalid.Analyzer,
+	modulejs.Analyzer,
+	// Tier 2: Security/Policy violations
+	coderules.Analyzer,
+	trackingscripts.Analyzer,
+	virusscan.Analyzer,
+	safelinks.Analyzer,
+	unsafesvg.Analyzer,
+	osvscanner.Analyzer,
+	// Tier 3: Build/Integrity issues
+	gomanifest.Analyzer,
+	binarypermissions.Analyzer,
+	backendbinary.Analyzer,
+	manifest.Analyzer,
+}
 
 var Analyzer = &analysis.Analyzer{
 	Name:     "llmreview",
 	Requires: []*analysis.Analyzer{sourcecode.Analyzer},
 	Run:      run,
-	Rules:    []*analysis.Rule{llmIssueFound},
+	Rules:    []*analysis.Rule{llmIssueFound, llmReviewSkipped},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "LLM Review",
 		Description:  "Runs the code through Gemini LLM to check for security issues or disallowed usage.",
@@ -78,6 +121,23 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
+	// Check if any blocking analyzers reported errors - skip LLM review to save costs
+	// keep here before source code and key check for tests to work
+	for _, analyzer := range blockingAnalyzers {
+		if pass.AnalyzerHasErrors(analyzer) {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				llmReviewSkipped,
+				fmt.Sprintf("LLM review skipped due to errors in %s", analyzer.Name),
+				fmt.Sprintf(
+					"Fix the errors reported by %s before LLM review can run.",
+					analyzer.Name,
+				),
+			)
+			return nil, nil
+		}
+	}
+
 	var err error
 	// only run if sourcecode.Analyzer succeeded
 	sourceCodeDir, ok := pass.ResultOf[sourcecode.Analyzer].(string)
@@ -113,11 +173,17 @@ func run(pass *analysis.Pass) (any, error) {
 			detailParts = append(detailParts, answer.Answer)
 
 			if answer.CodeSnippet != "" {
-				detailParts = append(detailParts, fmt.Sprintf("**Code Snippet:**\n```\n%s\n```", answer.CodeSnippet))
+				detailParts = append(
+					detailParts,
+					fmt.Sprintf("**Code Snippet:**\n```\n%s\n```", answer.CodeSnippet),
+				)
 			}
 
 			if len(answer.Files) > 0 {
-				detailParts = append(detailParts, fmt.Sprintf("**Files:** %s", strings.Join(answer.Files, ", ")))
+				detailParts = append(
+					detailParts,
+					fmt.Sprintf("**Files:** %s", strings.Join(answer.Files, ", ")),
+				)
 			}
 
 			detail := strings.Join(detailParts, "\n\n")

--- a/pkg/analysis/passes/llmreview/llmreview_test.go
+++ b/pkg/analysis/passes/llmreview/llmreview_test.go
@@ -1,0 +1,76 @@
+package llmreview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
+)
+
+func TestLLMReviewSkipsWhenBlockingAnalyzerHasErrors(t *testing.T) {
+	// Simulate diagnostics from a blocking analyzer (archive)
+	diagnostics := analysis.Diagnostics{
+		archive.Analyzer.Name: []analysis.Diagnostic{
+			{
+				Name:     "empty-archive",
+				Severity: analysis.Error,
+				Title:    "Archive is empty",
+			},
+		},
+	}
+
+	pass := &analysis.Pass{
+		AnalyzerName: Analyzer.Name,
+		ResultOf:     map[*analysis.Analyzer]any{
+			// sourcecode returns nil when archive fails
+		},
+		Diagnostics: &diagnostics,
+		Report: func(analyzerName string, d analysis.Diagnostic) {
+			diagnostics[analyzerName] = append(diagnostics[analyzerName], d)
+		},
+	}
+
+	_, err := run(pass)
+	assert.NoError(t, err)
+
+	// Check that llmReviewSkipped diagnostic was reported
+	llmDiags := diagnostics[Analyzer.Name]
+	assert.Len(t, llmDiags, 1)
+	assert.Equal(t, "llm-review-skipped", llmDiags[0].Name)
+	assert.Contains(t, llmDiags[0].Title, archive.Analyzer.Name)
+}
+
+func TestLLMReviewDoesNotSkipOnWarnings(t *testing.T) {
+	// Simulate diagnostics with only warnings (no errors)
+	diagnostics := analysis.Diagnostics{
+		metadata.Analyzer.Name: []analysis.Diagnostic{
+			{
+				Name:     "some-warning",
+				Severity: analysis.Warning,
+				Title:    "This is just a warning",
+			},
+		},
+	}
+
+	pass := &analysis.Pass{
+		AnalyzerName: Analyzer.Name,
+		ResultOf:     map[*analysis.Analyzer]any{},
+		Diagnostics:  &diagnostics,
+		Report: func(analyzerName string, d analysis.Diagnostic) {
+			diagnostics[analyzerName] = append(diagnostics[analyzerName], d)
+		},
+	}
+
+	_, err := run(pass)
+	assert.NoError(t, err)
+
+	// LLM review should NOT have reported a skip (it will exit early due to no source code)
+	// But importantly, it should NOT have reported llmReviewSkipped
+	llmDiags := diagnostics[Analyzer.Name]
+	for _, d := range llmDiags {
+		assert.NotEqual(t, "llm-review-skipped", d.Name, "should not skip on warnings only")
+	}
+}

--- a/pkg/analysis/passes/unsafesvg/unsafesvg.go
+++ b/pkg/analysis/passes/unsafesvg/unsafesvg.go
@@ -16,7 +16,7 @@ var (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name:     "manifest",
+	Name:     "unsafesvg",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
 	Rules:    []*analysis.Rule{unsafeSvgFile},
@@ -47,7 +47,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 		err = svgValidator.Validate(svgContent)
 		if err != nil {
-			pass.ReportResult(pass.AnalyzerName, unsafeSvgFile, fmt.Sprintf("SVG file %s is unsafe", svgFile), err.Error())
+			pass.ReportResult(
+				pass.AnalyzerName,
+				unsafeSvgFile,
+				fmt.Sprintf("SVG file %s is unsafe", svgFile),
+				err.Error(),
+			)
 		}
 
 	}

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -101,6 +101,14 @@ func TestIntegration(t *testing.T) {
 							Name:     "nested-plugins-not-declared",
 						},
 					},
+					"llmreview": {
+						{
+							Severity: "suspected",
+							Title:    "LLM review skipped due to errors in manifest",
+							Detail:   "Fix the errors reported by manifest before LLM review can run.",
+							Name:     "llm-review-skipped",
+						},
+					},
 					"manifest": {
 						{
 							Severity: "error",
@@ -165,6 +173,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "Plugin archive is improperly structured",
 							Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
 							Name:     "zip-invalid",
+						},
+					},
+					"llmreview": {
+						{
+							Severity: "suspected",
+							Title:    "LLM review skipped due to errors in archive",
+							Detail:   "Fix the errors reported by archive before LLM review can run.",
+							Name:     "llm-review-skipped",
 						},
 					},
 				},
@@ -253,6 +269,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "You can include a sponsorship link if you want users to support your work",
 							Detail:   "Consider to add a sponsorship link in your plugin.json file (Info.Links section: with Name: 'sponsor' or Name: 'sponsorship'), which will be shown on the plugin details page to allow users to support your work if they wish.",
 							Name:     "sponsorshiplink",
+						},
+					},
+					"llmreview": {
+						{
+							Severity: "suspected",
+							Title:    "LLM review skipped due to errors in metadatavalid",
+							Detail:   "Fix the errors reported by metadatavalid before LLM review can run.",
+							Name:     "llm-review-skipped",
 						},
 					},
 				},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -46,6 +46,7 @@ var tests = []struct {
 		"CHANGELOG.md is empty",
 		"You can include a sponsorship link if you want users to support your work",
 		"plugin.json: plugin id should follow the format org-name-type",
+		"LLM review skipped due to errors in metadatavalid",
 	}},
 }
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -17,6 +17,7 @@ var tests = []struct {
 }{
 	{Dir: "EmptyArchive", Messages: []string{
 		"Archive is empty",
+		"LLM review skipped due to errors in archive",
 	}},
 	{Dir: "EmptyDirectory", Messages: []string{
 		"missing plugin.json",
@@ -26,6 +27,7 @@ var tests = []struct {
 		"LICENSE file not found",
 		"plugin.json not found",
 		"missing CHANGELOG.md",
+		"LLM review skipped due to errors in metadata",
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
 		"empty manifest",


### PR DESCRIPTION
The LLM-review is slow and costs to run, we want to skip running it in cases where we know there are bigger errors to fix than what the LLM review could find.

I have collected a hand-picked list of validators that create strong signals of a plugin having deep problems that need fixing before an LLM can start to help.

