### PR TITLE
codediff: do not run when specific validators generated errors

### DIFF
--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -191,6 +191,14 @@ func TestIntegration(t *testing.T) {
 							Name:     "llm-review-skipped",
 						},
 					},
+					"codediff": {
+						{
+							Severity: "suspected",
+							Title:    "Code diff skipped due to errors in archive",
+							Detail:   "Fix the errors reported by archive before code diff can run.",
+							Name:     "code-diff-skipped",
+						},
+					},
 				},
 			},
 		},
@@ -285,6 +293,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "LLM review skipped due to errors in metadatavalid",
 							Detail:   "Fix the errors reported by metadatavalid before LLM review can run.",
 							Name:     "llm-review-skipped",
+						},
+					},
+					"codediff": {
+						{
+							Severity: "suspected",
+							Title:    "Code diff skipped due to errors in metadatavalid",
+							Detail:   "Fix the errors reported by metadatavalid before code diff can run.",
+							Name:     "code-diff-skipped",
 						},
 					},
 				},

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -125,6 +125,14 @@ func TestIntegration(t *testing.T) {
 							Name:     "sponsorshiplink",
 						},
 					},
+					"codediff": {
+						{
+							Severity: "suspected",
+							Title:    "Code diff skipped due to errors in manifest",
+							Detail:   "Fix the errors reported by manifest before code diff can run.",
+							Name:     "code-diff-skipped",
+						},
+					},
 				},
 			},
 		},
@@ -165,6 +173,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "Plugin archive is improperly structured",
 							Detail:   "It is possible your plugin archive structure is incorrect. Please see https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin for more information on how to package a plugin.",
 							Name:     "zip-invalid",
+						},
+					},
+					"codediff": {
+						{
+							Severity: "suspected",
+							Title:    "Code diff skipped due to errors in archive",
+							Detail:   "Fix the errors reported by archive before code diff can run.",
+							Name:     "code-diff-skipped",
 						},
 					},
 				},
@@ -253,6 +269,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "You can include a sponsorship link if you want users to support your work",
 							Detail:   "Consider to add a sponsorship link in your plugin.json file (Info.Links section: with Name: 'sponsor' or Name: 'sponsorship'), which will be shown on the plugin details page to allow users to support your work if they wish.",
 							Name:     "sponsorshiplink",
+						},
+					},
+					"codediff": {
+						{
+							Severity: "suspected",
+							Title:    "Code diff skipped due to errors in metadatavalid",
+							Detail:   "Fix the errors reported by metadatavalid before code diff can run.",
+							Name:     "code-diff-skipped",
 						},
 					},
 				},

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -29,7 +29,7 @@ var tests = []struct {
 		"plugin.json not found",
 		"missing CHANGELOG.md",
 		"LLM review skipped due to errors in metadata",
-		"Code diff skipped due to errors in archive",
+		"Code diff skipped due to errors in metadata",
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
 		"empty manifest",

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -17,6 +17,7 @@ var tests = []struct {
 }{
 	{Dir: "EmptyArchive", Messages: []string{
 		"Archive is empty",
+		"Code diff skipped due to errors in archive",
 	}},
 	{Dir: "EmptyDirectory", Messages: []string{
 		"missing plugin.json",
@@ -26,6 +27,7 @@ var tests = []struct {
 		"LICENSE file not found",
 		"plugin.json not found",
 		"missing CHANGELOG.md",
+		"Code diff skipped due to errors in metadata",
 	}},
 	{Dir: "AllFilesPresentButEmpty", Messages: []string{
 		"empty manifest",
@@ -44,6 +46,7 @@ var tests = []struct {
 		"CHANGELOG.md is empty",
 		"You can include a sponsorship link if you want users to support your work",
 		"plugin.json: plugin id should follow the format org-name-type",
+		"Code diff skipped due to errors in metadatavalid",
 	}},
 }
 


### PR DESCRIPTION
Same as https://github.com/grafana/plugin-validator/pull/499 but for code-diff

The code diff is slow and costs to run, we want to skip running it in cases where we know there are bigger errors to fix than what the LLM review could find.


