### PR TITLE
Remove console.debug pattern from semgrep rules

### DIFF
--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -116,7 +116,6 @@ rules:
       - pattern: console.log(...)
       - pattern: console.info(...)
       - pattern: console.table(...)
-      - pattern: console.debug(...)
       - pattern: console.clear(...)
       - pattern: console.count(...)
       - pattern: console.countReset(...)


### PR DESCRIPTION
Removed console.debug pattern from semgrep rules.