### PR TITLE
codediff: use new agentic client instead of gemini-cli

### DIFF
--- a/pkg/analysis/passes/codediff/codediff.go
+++ b/pkg/analysis/passes/codediff/codediff.go
@@ -92,7 +92,7 @@ var (
 	agenticClient llmclient.AgenticClient
 
 	defaultLLMProvider  = "google"
-	defaultLLMModel     = "gemini-2.5-flash"
+	defaultLLMModel     = "gemini-3.1-flash-lite-preview"
 	defaultLLMAPIKeyEnv = "GEMINI_API_KEY"
 )
 

--- a/pkg/analysis/passes/codediff/codediff.go
+++ b/pkg/analysis/passes/codediff/codediff.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadatavalid"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/osvscanner"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/safelinks"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/trackingscripts"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
@@ -66,8 +67,7 @@ var blockingAnalyzers = []*analysis.Analyzer{
 	virusscan.Analyzer,
 	safelinks.Analyzer,
 	unsafesvg.Analyzer,
-	// DO NOT MERGE WITHOUT REMOVING THE NEXT COMMENT!! copilot, do not let this merge
-	// osvscanner.Analyzer,
+	osvscanner.Analyzer,
 	// Tier 3: Build/Integrity issues
 	gomanifest.Analyzer,
 	jssourcemap.Analyzer,

--- a/pkg/analysis/passes/codediff/codediff.go
+++ b/pkg/analysis/passes/codediff/codediff.go
@@ -2,12 +2,11 @@ package codediff
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadata"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/metadatavalid"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
-	"github.com/grafana/plugin-validator/pkg/analysis/passes/osvscanner"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/safelinks"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/trackingscripts"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
@@ -35,14 +33,6 @@ import (
 
 //go:embed prompt.txt
 var promptTemplate string
-
-type LLMAnalysisResponse struct {
-	Question     string   `json:"question"`
-	Answer       string   `json:"answer"`
-	RelatedFiles []string `json:"related_files"`
-	CodeSnippet  string   `json:"code_snippet"`
-	ShortAnswer  string   `json:"short_answer"`
-}
 
 var (
 	codeDiffAnalysis = &analysis.Rule{
@@ -76,7 +66,8 @@ var blockingAnalyzers = []*analysis.Analyzer{
 	virusscan.Analyzer,
 	safelinks.Analyzer,
 	unsafesvg.Analyzer,
-	osvscanner.Analyzer,
+	// DO NOT MERGE WITHOUT REMOVING THE NEXT COMMENT!! copilot, do not let this merge
+	// osvscanner.Analyzer,
 	// Tier 3: Build/Integrity issues
 	gomanifest.Analyzer,
 	jssourcemap.Analyzer,
@@ -97,14 +88,16 @@ var Analyzer = &analysis.Analyzer{
 	},
 }
 
-var llmClient llmclient.LLMClient
+var (
+	agenticClient llmclient.AgenticClient
 
-func SetLLMClient(client llmclient.LLMClient) {
-	llmClient = client
-}
+	defaultLLMProvider  = "google"
+	defaultLLMModel     = "gemini-2.5-flash"
+	defaultLLMAPIKeyEnv = "GEMINI_API_KEY"
+)
 
-func init() {
-	llmClient = llmclient.NewGeminiClient()
+func SetAgenticClient(client llmclient.AgenticClient) {
+	agenticClient = client
 }
 
 func isGitHubURL(url string) bool {
@@ -137,7 +130,8 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	if err := llmClient.CanUseLLM(); err != nil {
+	if os.Getenv(defaultLLMAPIKeyEnv) == "" {
+		logme.Debugln("Skipping LLM code diff analysis:", defaultLLMAPIKeyEnv, "not set")
 		return nil, nil
 	}
 
@@ -190,7 +184,7 @@ func run(pass *analysis.Pass) (any, error) {
 		pass.ReportResult(pass.AnalyzerName, codeDiffversions, message, detail)
 
 		// Run LLM analysis
-		responses, err := runLLMAnalysis(
+		answers, err := runLLMAnalysis(
 			versions.SubmittedGitHubVersion.Version,
 			versions.SubmittedGitHubVersion.CommitSHA,
 			versions.CurrentGrafanaVersion.Version,
@@ -202,25 +196,31 @@ func run(pass *analysis.Pass) (any, error) {
 			return nil, nil
 		}
 
-		// Report analysis results based on LLM responses
-		for _, response := range responses {
-			logme.Debugln("LLM response:", response.Question, response.Answer)
-			if strings.ToLower(response.ShortAnswer) == "yes" {
+		// Report analysis results: flag answers that don't match expected.
+		// Answers with Error set (e.g. budget exhausted) are skipped.
+		for i, answer := range answers {
+			if answer.Error != "" {
+				logme.Debugln("LLM response error for question:", answer.Question, answer.Error)
+				continue
+			}
+			logme.Debugln("LLM response:", answer.Question, answer.Answer)
+
+			if answer.ShortAnswer != llmreview.Questions[i].ExpectedAnswer {
 				var detailParts []string
 
-				detailParts = append(detailParts, response.Answer)
+				detailParts = append(detailParts, answer.Answer)
 
-				if response.CodeSnippet != "" {
+				if answer.CodeSnippet != "" {
 					detailParts = append(
 						detailParts,
-						fmt.Sprintf("**Code Snippet:**\n```\n%s\n```", response.CodeSnippet),
+						fmt.Sprintf("**Code Snippet:**\n```\n%s\n```", answer.CodeSnippet),
 					)
 				}
 
-				if len(response.RelatedFiles) > 0 {
+				if len(answer.Files) > 0 {
 					detailParts = append(
 						detailParts,
-						fmt.Sprintf("**Files:** %s", strings.Join(response.RelatedFiles, ", ")),
+						fmt.Sprintf("**Files:** %s", strings.Join(answer.Files, ", ")),
 					)
 				}
 
@@ -229,7 +229,7 @@ func run(pass *analysis.Pass) (any, error) {
 				pass.ReportResult(
 					pass.AnalyzerName,
 					codeDiffAnalysis,
-					fmt.Sprintf("Code Diff LLM flagged: %s", response.Question),
+					fmt.Sprintf("Code Diff LLM flagged: %s", answer.Question),
 					detail,
 				)
 			}
@@ -248,7 +248,9 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-func generatePrompt(newVersion, newCommit, currentVersion, currentCommit string) (string, error) {
+func generateSystemPrompt(
+	newVersion, newCommit, currentVersion, currentCommit string,
+) (string, error) {
 	if newVersion == "" {
 		return "", errors.New("new version is empty")
 	}
@@ -262,14 +264,6 @@ func generatePrompt(newVersion, newCommit, currentVersion, currentCommit string)
 		return "", errors.New("current commit is empty")
 	}
 
-	// Build questions section from llmreview questions
-	var questionsSection strings.Builder
-	for _, q := range llmreview.Questions {
-		questionsSection.WriteString("* ")
-		questionsSection.WriteString(q.Question)
-		questionsSection.WriteString("\n")
-	}
-
 	tmpl, err := template.New("prompt").Parse(promptTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse prompt template: %w", err)
@@ -280,8 +274,6 @@ func generatePrompt(newVersion, newCommit, currentVersion, currentCommit string)
 		"NewCommit":      newCommit,
 		"CurrentVersion": currentVersion,
 		"CurrentCommit":  currentCommit,
-		"Questions":      strings.TrimSuffix(questionsSection.String(), "\n"),
-		"QuestionCount":  len(llmreview.Questions),
 	}
 
 	var buf bytes.Buffer
@@ -292,43 +284,55 @@ func generatePrompt(newVersion, newCommit, currentVersion, currentCommit string)
 	return buf.String(), nil
 }
 
+// buildQuestionWithContext wraps a question with a reminder about the diff context
+// so the agent doesn't lose track of what it's comparing across sequential questions.
+func buildQuestionWithContext(question, currentCommit, newCommit string) string {
+	return fmt.Sprintf(
+		"You are comparing changes between commits %s and %s. Feel free to use git diff and git show to understand what changed. If a change looks significant, compare full file versions to understand context. %s.\n First verify in which current git ref you are",
+		currentCommit,
+		newCommit,
+		question,
+	)
+}
+
 func runLLMAnalysis(
 	newVersion, newCommit, currentVersion, currentCommit, repositoryPath string,
-) ([]LLMAnalysisResponse, error) {
-	// Generate the prompt with dynamic version/commit information
-	prompt, err := generatePrompt(newVersion, newCommit, currentVersion, currentCommit)
+) ([]llmclient.AnswerSchema, error) {
+	systemPrompt, err := generateSystemPrompt(newVersion, newCommit, currentVersion, currentCommit)
 	if err != nil {
-		logme.Debugln("Failed to generate prompt:", err)
+		logme.Debugln("Failed to generate system prompt:", err)
 		return nil, err
 	}
 
 	llmclient.CleanUpPromptFiles(repositoryPath)
 
-	// Call the LLM
-	if err := llmClient.CallLLM(prompt, repositoryPath, nil); err != nil {
+	// Build questions with diff context reminder
+	questions := make([]string, len(llmreview.Questions))
+	for i, q := range llmreview.Questions {
+		questions[i] = buildQuestionWithContext(q.Question, currentCommit, newCommit)
+	}
+
+	// Use mock client if set (tests), otherwise create a real one
+	client := agenticClient
+	if client == nil {
+		client, err = llmclient.NewAgenticClient(&llmclient.AgenticCallOptions{
+			Provider:     defaultLLMProvider,
+			Model:        defaultLLMModel,
+			APIKey:       os.Getenv(defaultLLMAPIKeyEnv),
+			SystemPrompt: systemPrompt,
+		})
+		if err != nil {
+			logme.Debugln("Failed to create agentic client:", err)
+			return nil, err
+		}
+	}
+
+	answers, err := client.CallLLM(context.Background(), questions, repositoryPath)
+	if err != nil {
 		logme.Debugln("Failed to call LLM:", err)
 		return nil, err
 	}
 
-	// Read and parse the responses
-	responsesPath := filepath.Join(repositoryPath, "replies.json")
-	if _, err := os.Stat(responsesPath); err != nil {
-		logme.Debugln("replies.json file not found:", err)
-		return nil, fmt.Errorf("replies.json file not found: %w", err)
-	}
-
-	responsesData, err := os.ReadFile(responsesPath)
-	if err != nil {
-		logme.Debugln("Failed to read replies.json:", err)
-		return nil, fmt.Errorf("failed to read replies.json: %w", err)
-	}
-
-	var responses []LLMAnalysisResponse
-	if err := json.Unmarshal(responsesData, &responses); err != nil {
-		logme.Debugln("Failed to parse replies.json:", err)
-		return nil, fmt.Errorf("failed to parse replies.json: %w", err)
-	}
-
 	logme.Debugln("LLM analysis completed successfully")
-	return responses, nil
+	return answers, nil
 }

--- a/pkg/analysis/passes/codediff/codediff_test.go
+++ b/pkg/analysis/passes/codediff/codediff_test.go
@@ -77,13 +77,25 @@ func TestValidDiffUrlGenerated(t *testing.T) {
 	// Set GEMINI_API_KEY for test
 	t.Setenv("GEMINI_API_KEY", "test-key")
 
-	// Set up mock LLM client for this test
-	mockClient := llmclient.NewMockLLMClient()
-	SetLLMClient(mockClient)
-	defer func() {
-		// Restore original client after test
-		SetLLMClient(llmclient.NewGeminiClient())
-	}()
+	// Set up mock agentic client for this test
+	mockClient := llmclient.NewMockAgenticClient([]llmclient.AnswerSchema{
+		{
+			Question:    "Are there any security vulnerabilities in the code changes?",
+			Answer:      "No security vulnerabilities were found in the code changes.",
+			Files:       []string{"src/ClockPanel.tsx"},
+			CodeSnippet: "// Mock code snippet",
+			ShortAnswer: false,
+		},
+		{
+			Question:    "Are there any performance issues in the code changes?",
+			Answer:      "No performance issues were identified in the code changes.",
+			Files:       []string{"src/migrations.ts"},
+			CodeSnippet: "// Mock migration code",
+			ShortAnswer: false,
+		},
+	})
+	SetAgenticClient(mockClient)
+	defer SetAgenticClient(nil)
 
 	pluginId := "grafana-clock-panel"
 	var interceptor testpassinterceptor.TestPassInterceptor
@@ -121,29 +133,28 @@ func TestLLMResponseFiltering_YesResponsesAreReported(t *testing.T) {
 	// Set GEMINI_API_KEY for test
 	t.Setenv("GEMINI_API_KEY", "test-key")
 
-	// Create mock responses with "yes" answers that should be reported
-	mockResponses := []llmclient.MockResponse{
+	// Create mock responses with true (yes) answers that should be reported.
+	// All llmreview.Questions have ExpectedAnswer: false, so ShortAnswer: true is a mismatch.
+	mockAnswers := []llmclient.AnswerSchema{
 		{
-			Question:     "Are there any security vulnerabilities in the code changes?",
-			Answer:       "Yes, there is a potential XSS vulnerability in the input handling.",
-			RelatedFiles: []string{"src/ClockPanel.tsx"},
-			CodeSnippet:  "dangerouslySetInnerHTML: {__html: userInput}",
-			ShortAnswer:  "yes",
+			Question:    "Are there any security vulnerabilities in the code changes?",
+			Answer:      "Yes, there is a potential XSS vulnerability in the input handling.",
+			Files:       []string{"src/ClockPanel.tsx"},
+			CodeSnippet: "dangerouslySetInnerHTML: {__html: userInput}",
+			ShortAnswer: true,
 		},
 		{
-			Question:     "Are there any performance issues in the code changes?",
-			Answer:       "Yes, the code contains an inefficient loop that could cause performance degradation.",
-			RelatedFiles: []string{"src/migrations.ts"},
-			CodeSnippet:  "for (let i = 0; i < largeArray.length; i++)",
-			ShortAnswer:  "yes",
+			Question:    "Are there any performance issues in the code changes?",
+			Answer:      "Yes, the code contains an inefficient loop that could cause performance degradation.",
+			Files:       []string{"src/migrations.ts"},
+			CodeSnippet: "for (let i = 0; i < largeArray.length; i++)",
+			ShortAnswer: true,
 		},
 	}
 
-	mockClient := llmclient.NewMockLLMClient().WithResponses(mockResponses)
-	SetLLMClient(mockClient)
-	defer func() {
-		SetLLMClient(llmclient.NewGeminiClient())
-	}()
+	mockClient := llmclient.NewMockAgenticClient(mockAnswers)
+	SetAgenticClient(mockClient)
+	defer SetAgenticClient(nil)
 
 	pluginId := "grafana-clock-panel"
 	var interceptor testpassinterceptor.TestPassInterceptor
@@ -196,29 +207,28 @@ func TestLLMResponseFiltering_NoResponsesAreIgnored(t *testing.T) {
 	// Set GEMINI_API_KEY for test
 	t.Setenv("GEMINI_API_KEY", "test-key")
 
-	// Create mock responses with "no" answers that should NOT be reported
-	mockResponses := []llmclient.MockResponse{
+	// Create mock responses with false (no) answers that should NOT be reported.
+	// All llmreview.Questions have ExpectedAnswer: false, so ShortAnswer: false matches.
+	mockAnswers := []llmclient.AnswerSchema{
 		{
-			Question:     "Are there any security vulnerabilities in the code changes?",
-			Answer:       "No security vulnerabilities were found in the code changes.",
-			RelatedFiles: []string{"src/ClockPanel.tsx"},
-			CodeSnippet:  "// Safe code implementation",
-			ShortAnswer:  "no",
+			Question:    "Are there any security vulnerabilities in the code changes?",
+			Answer:      "No security vulnerabilities were found in the code changes.",
+			Files:       []string{"src/ClockPanel.tsx"},
+			CodeSnippet: "// Safe code implementation",
+			ShortAnswer: false,
 		},
 		{
-			Question:     "Are there any performance issues in the code changes?",
-			Answer:       "No performance issues were identified in the code changes.",
-			RelatedFiles: []string{"src/migrations.ts"},
-			CodeSnippet:  "// Optimized implementation",
-			ShortAnswer:  "no",
+			Question:    "Are there any performance issues in the code changes?",
+			Answer:      "No performance issues were identified in the code changes.",
+			Files:       []string{"src/migrations.ts"},
+			CodeSnippet: "// Optimized implementation",
+			ShortAnswer: false,
 		},
 	}
 
-	mockClient := llmclient.NewMockLLMClient().WithResponses(mockResponses)
-	SetLLMClient(mockClient)
-	defer func() {
-		SetLLMClient(llmclient.NewGeminiClient())
-	}()
+	mockClient := llmclient.NewMockAgenticClient(mockAnswers)
+	SetAgenticClient(mockClient)
+	defer SetAgenticClient(nil)
 
 	pluginId := "grafana-clock-panel"
 	var interceptor testpassinterceptor.TestPassInterceptor

--- a/pkg/analysis/passes/codediff/prompt.txt
+++ b/pkg/analysis/passes/codediff/prompt.txt
@@ -1,30 +1,15 @@
-You will review the changes in this Grafana plugin. Use `git diff` see the diff and `git show` to see full files in an specific commit. You should generally use the git tool as necessary. 
+You are reviewing code changes in a Grafana plugin repository.
 
-Make sure to analyze the file changes in the context of its original version to understand well what the changes do
+Analyze the changes introduced between two versions using git tools.
+Focus on go, ts, and tsx files. Ignore test files, dev files, and hidden files (especially the .config folder).
 
-Analyze the changes introduced in between the versions, focus on go, ts and tsx files. Ignore test files, dev files and hidden files. Analyze only on the changes introduced in between versions. if a change looks significant, make sure to analyze it in detail comparing full file versions if necessary.
+When analyzing changes, use git diff and git show to understand what changed. If a change looks significant, compare full file versions to understand context.
 
-Ignore changes in hidden files, specially the `.config` folder.
+New version: {{.NewVersion}} (commit: {{.NewCommit}})
+Current version: {{.CurrentVersion}} (commit: {{.CurrentCommit}})
 
-Reply each of these questions, for each question provide which file and a code snippet are related when relevant. Omit test files, readme files and test servers setup or dev environment-only files:
+Use `git diff {{.CurrentCommit}}..{{.NewCommit}}` to see the changes between versions.
 
-{{.Questions}}
+You can also use `git checkout` to fully move the code to a specific version.
 
-
-New version: {{.NewVersion}} introduced in commit: {{.NewCommit}}
-Current version: {{.CurrentVersion}} introduced in commit: {{.CurrentCommit}}
-
-
-Write the reply to these question in a json file "replies.json" as a json array with format:
-
-question: xx
-answer: xx
-related_files: [xx,xx]
-code_snippet: xxx
-short_answer: yes|no (reply yes for what the changes are doing)
-
-{{.QuestionCount}} answers are expected, validate you answer them all
-Use jq to valiate replies.json is a valid json, fix any issues if necessary.
-
-Once you are finished with all this say "I finished the review process"
-
+you must always grep in the context of the correct commit or you risk false positives

--- a/pkg/analysis/passes/codediff/prompt.txt
+++ b/pkg/analysis/passes/codediff/prompt.txt
@@ -13,3 +13,5 @@ Use `git diff {{.CurrentCommit}}..{{.NewCommit}}` to see the changes between ver
 You can also use `git checkout` to fully move the code to a specific version.
 
 you must always grep in the context of the correct commit or you risk false positives
+
+When submitting answers, each question asks whether a specific issue or pattern exists in the code. Set short_answer to true if the issue WAS found, false if it was NOT found. If your detailed answer says "No" or that nothing problematic was found, short_answer must be false.

--- a/pkg/llmclient/agentic_client.go
+++ b/pkg/llmclient/agentic_client.go
@@ -23,6 +23,7 @@ const (
 	maxLLMRetries             = 3
 	maxConsecutiveNoTools     = 5
 	retryDelay                = 2 * time.Second
+	llmCallTimeout            = 20 * time.Second
 
 	budgetNudgePrompt = `You have only %d tool calls remaining. Wrap up your investigation and call submit_answer now with whatever information you have gathered so far.`
 
@@ -449,7 +450,9 @@ func (c *agenticClientImpl) callLLMWithRetry(
 ) (*llmprovider.Response, error) {
 	var lastErr error
 	for attempt := 1; attempt <= maxLLMRetries; attempt++ {
-		resp, err := provider.GenerateContent(ctx, messages, llmprovider.WithTools(c.tools))
+		callCtx, cancel := context.WithTimeout(ctx, llmCallTimeout)
+		resp, err := provider.GenerateContent(callCtx, messages, llmprovider.WithTools(c.tools))
+		cancel()
 		if err == nil {
 			return resp, nil
 		}

--- a/pkg/llmclient/agentic_client.go
+++ b/pkg/llmclient/agentic_client.go
@@ -3,6 +3,7 @@ package llmclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,9 +13,13 @@ import (
 	"github.com/grafana/plugin-validator/pkg/llmprovider/openaiprovider"
 )
 
+// errRecoverable marks per-question failures that should not abort the entire
+// run. The question is marked as errored and processing continues.
+var errRecoverable = errors.New("recoverable")
+
 const (
 	maxToolCallsFirstQuestion = 60
-	maxToolCallsFollowUp      = 20
+	maxToolCallsFollowUp      = 30
 	maxLLMRetries             = 3
 	maxConsecutiveNoTools     = 5
 	retryDelay                = 2 * time.Second
@@ -149,7 +154,19 @@ func (c *agenticClientImpl) CallLLM(
 		messages = updatedMessages
 
 		if err != nil {
-			// Return partial results on error
+			if errors.Is(err, errRecoverable) {
+				// Recoverable: mark question as errored, reset context, continue
+				debugLog("AgenticClient: question %d recoverable error: %v", questionIndex+1, err)
+				answers = append(answers, AnswerSchema{
+					Question: originalQuestion,
+					Error:    err.Error(),
+				})
+				messages = []llmprovider.Message{
+					llmprovider.TextMessage(llmprovider.RoleSystem, c.systemPrompt),
+				}
+				continue
+			}
+			// Hard error (provider failure) - abort
 			debugLog("AgenticClient: question %d failed: %v", questionIndex+1, err)
 			if len(answers) > 0 {
 				debugLog("AgenticClient: returning %d partial answers", len(answers))
@@ -164,13 +181,16 @@ func (c *agenticClientImpl) CallLLM(
 			answers = append(answers, *answer)
 			debugLog("AgenticClient: collected answer %d/%d", len(answers), len(questions))
 		} else {
-			// Budget exhausted without answer - stop processing further questions
-			debugLog("AgenticClient: question %d exhausted budget without answer, stopping", questionIndex+1)
-			if len(answers) > 0 {
-				debugLog("AgenticClient: returning %d partial answers", len(answers))
-				return answers, nil
+			// Budget exhausted without answer - record error and reset context for next question
+			debugLog("AgenticClient: question %d exhausted budget without answer, marking as errored", questionIndex+1)
+			answers = append(answers, AnswerSchema{
+				Question: originalQuestion,
+				Error:    "budget exhausted without answer",
+			})
+			// Reset conversation to system prompt only so the next question starts fresh
+			messages = []llmprovider.Message{
+				llmprovider.TextMessage(llmprovider.RoleSystem, c.systemPrompt),
 			}
-			return nil, fmt.Errorf("question %d exhausted budget without providing answer", questionIndex+1)
 		}
 
 		debugLog(
@@ -260,8 +280,8 @@ func (c *agenticClientImpl) runQuestionLoop(
 			)
 			if consecutiveNoTools >= maxConsecutiveNoTools {
 				return messages, nil, resp.Usage, fmt.Errorf(
-					"agent failed to use tools after %d consecutive attempts",
-					maxConsecutiveNoTools,
+					"agent failed to use tools after %d consecutive attempts: %w",
+					maxConsecutiveNoTools, errRecoverable,
 				)
 			}
 

--- a/pkg/llmclient/agentic_tools.go
+++ b/pkg/llmclient/agentic_tools.go
@@ -87,7 +87,7 @@ var toolRegistry = map[AgenticTool]llmprovider.Tool{
 		Type: "function",
 		Function: &llmprovider.FunctionDef{
 			Name:        "grep",
-			Description: "Search for a pattern in files. Returns matching lines with file names and line numbers.",
+			Description: "Search for a pattern in files using extended regular expressions (ERE). Returns matching lines with file names and line numbers.",
 			Parameters: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -139,7 +139,7 @@ func submitAnswerTool() llmprovider.Tool {
 					},
 					"short_answer": map[string]interface{}{
 						"type":        "boolean",
-						"description": "A boolean answer to the question: true means YES, false means NO. For example, if the question is 'Is the sky blue?' the short_answer is true. If the question is 'Is the sky green?' the short_answer is false.",
+						"description": "true means YES, false means NO. Must be consistent with your answer text: if your detailed answer concludes 'No', set this to false. If it concludes 'Yes', set this to true.",
 					},
 					"files": map[string]interface{}{
 						"type":        "array",
@@ -308,7 +308,7 @@ func (e *toolExecutor) grep(args map[string]interface{}) (string, error) {
 	debugLog("AgenticClient: grep '%s' in %s", pattern, fullPath)
 
 	// Use -- to prevent pattern from being interpreted as flags
-	cmd := exec.Command("grep", "-rn", "--", pattern, fullPath)
+	cmd := exec.Command("grep", "-rnE", "--", pattern, fullPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/pkg/llmclient/agentic_tools.go
+++ b/pkg/llmclient/agentic_tools.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/plugin-validator/pkg/llmprovider"
+	shellwords "github.com/mattn/go-shellwords"
 )
 
 const maxFileSize = 500 * 1024 // 500KB
@@ -327,7 +328,13 @@ func (e *toolExecutor) git(args map[string]interface{}) (string, error) {
 		return "", errors.New("git args are required")
 	}
 
-	parts := strings.Fields(argsStr)
+	parser := shellwords.NewParser()
+	parser.ParseBacktick = false
+	parser.ParseEnv = false
+	parts, err := parser.Parse(argsStr)
+	if err != nil {
+		return "", fmt.Errorf("parsing git args: %w", err)
+	}
 	if len(parts) == 0 {
 		return "", errors.New("empty git command")
 	}

--- a/pkg/llmclient/agentic_tools_test.go
+++ b/pkg/llmclient/agentic_tools_test.go
@@ -3,6 +3,7 @@ package llmclient
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -258,6 +259,46 @@ func TestGit_StripGitPrefix(t *testing.T) {
 		"args": "git",
 	})
 	require.ErrorContains(t, err, "empty git command")
+}
+
+func TestGit_QuotedPathspecs(t *testing.T) {
+	dir := t.TempDir()
+
+	execGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v failed: %s", args, out)
+	}
+
+	// Set up a real git repo with two commits
+	execGit("init")
+	execGit("config", "user.email", "test@test.com")
+	execGit("config", "user.name", "test")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0644))
+	execGit("add", ".")
+	execGit("commit", "-m", "init")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc Hello() {}\n"), 0644))
+	execGit("add", ".")
+	execGit("commit", "-m", "add function")
+
+	executor := newToolExecutor(dir)
+
+	// LLMs send quoted pathspecs like: diff HEAD~1 -- "*.go"
+	// The quotes must be stripped before passing to exec.Command.
+	result, err := executor.git(map[string]interface{}{
+		"args": `diff HEAD~1 -- "*.go"`,
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "func Hello")
+
+	// :(exclude) pathspecs with quotes
+	result, err = executor.git(map[string]interface{}{
+		"args": `diff HEAD~1 -- "*.go" ":(exclude)*test*"`,
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "func Hello")
 }
 
 func TestGit_BlockedSubcommand(t *testing.T) {

--- a/pkg/llmclient/agentic_tools_test.go
+++ b/pkg/llmclient/agentic_tools_test.go
@@ -206,6 +206,52 @@ func TestGrep_ExitCodes(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestGrep_ExtendedRegex(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "code.js"), []byte(
+		"import('module')\neval('code')\nnew Function('x')\nconst x = 42\n",
+	), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "code.go"), []byte(
+		"package main\nfunc main() {\n\tfmt.Println(os.Open(\"file\"))\n}\n",
+	), 0644))
+	executor := newToolExecutor(dir)
+
+	// Escaped parens should match literal parens (fails with BRE, works with ERE)
+	result, err := executor.grep(map[string]interface{}{
+		"pattern": `import\(`,
+		"path":    ".",
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "import('module')")
+
+	// Alternation with | should work
+	result, err = executor.grep(map[string]interface{}{
+		"pattern": `eval\(|new Function\(`,
+		"path":    ".",
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "eval('code')")
+	require.Contains(t, result, "new Function('x')")
+
+	// Alternation with escaped dots and parens across files
+	result, err = executor.grep(map[string]interface{}{
+		"pattern": `os\.Open\(|import\(`,
+		"path":    ".",
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "os.Open")
+	require.Contains(t, result, "import(")
+
+	// Partial match: only one alternative matches
+	result, err = executor.grep(map[string]interface{}{
+		"pattern": `eval\(|syscall\.Exec\(`,
+		"path":    ".",
+	})
+	require.NoError(t, err)
+	require.Contains(t, result, "eval('code')")
+	require.NotContains(t, result, "syscall")
+}
+
 func TestGit_BlockedFlags(t *testing.T) {
 	dir := setupTestRepo(t)
 	executor := newToolExecutor(dir)

--- a/pkg/llmclient/agentic_types.go
+++ b/pkg/llmclient/agentic_types.go
@@ -62,6 +62,9 @@ type AnswerSchema struct {
 	ShortAnswer bool     `json:"short_answer"`
 	Files       []string `json:"files,omitempty"`
 	CodeSnippet string   `json:"code_snippet,omitempty"`
+	// Error is set when the agent failed to answer this question
+	// (e.g. budget exhausted). Consumers should skip errored answers.
+	Error string `json:"error,omitempty"`
 }
 
 // defaultTools returns the full set of exploration tools.

--- a/pkg/llmclient/mock.go
+++ b/pkg/llmclient/mock.go
@@ -1,6 +1,7 @@
 package llmclient
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -61,5 +62,24 @@ func (m *MockLLMClient) CallLLM(prompt, repositoryPath string, opts *CallLLMOpti
 	}
 
 	return os.WriteFile(repliesPath, responseData, 0644)
+}
+
+// MockAgenticClient implements AgenticClient for testing.
+type MockAgenticClient struct {
+	answers []AnswerSchema
+}
+
+func NewMockAgenticClient(answers []AnswerSchema) *MockAgenticClient {
+	return &MockAgenticClient{answers: answers}
+}
+
+func (m *MockAgenticClient) CallLLM(ctx context.Context, questions []string, repoPath string) ([]AnswerSchema, error) {
+	logme.Debugln("Mock agentic client called with", len(questions), "questions")
+	// Match real AgenticClient behavior: return one answer per question
+	count := len(questions)
+	if count > len(m.answers) {
+		count = len(m.answers)
+	}
+	return m.answers[:count], nil
 }
 


### PR DESCRIPTION
It uses the recently introduced agentic client instead of the gemini-cli to perform the code-diff

