### PR TITLE
chore(deps): set up renovate for Go version in go.mod and Dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,30 @@
       ],
       "groupName": "Dockerfile dependencies",
       "description": "Group all Dockerfile dependencies together"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
+      "rangeStrategy": "bump",
+      "groupName": "Go version",
+      "description": "Bump Go version in go.mod and group with Docker golang image"
+    },
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchDepNames": [
+        "golang"
+      ],
+      "groupName": "Go version",
+      "description": "Group golang Docker image with Go version updates"
     }
   ],
   "labels": [


### PR DESCRIPTION
Configures renovate to bump Go version in go.mod and Dockerfile when a new Go version is released.

Also groups those two together in one PR, rather than opening two.