### PR TITLE
build: build linux/amd64 Docker image on Mac OS ARM

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -55,6 +55,8 @@ func buildDockerImage() error {
 	return sh.RunV(
 		"docker",
 		"build",
+		"--platform",
+		"linux/amd64",
 		"--no-cache",
 		"--pull",
 		"-t",


### PR DESCRIPTION
Small fix to the Magefile to enforce linux/amd64 platform, which is required on Mac OS ARM in order to use Rosetta (x86 emulation). plugin-validator images in the registry aren't available for arm anyways, and without this change an ARM image is build and is not picked up by other tools that enforce linux/amd64 (e.g.: plugin-ci-workflows act tests running locally)