### PR TITLE
feat: support Anthropic and OpenAI as LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,26 @@ Locally:
 DEBUG=1 plugincheck2 -sourceCodeUri https://github.com/grafana/clock-panel/tree/v2.1.2 https://github.com/grafana/clock-panel/releases/download/v2.1.2/grafana-clock-panel-2.1.2.zip
 ```
 
+## LLM provider configuration
+
+The `llmreview` and `codediff` analyzers use an LLM to review plugin source code. Three providers are supported: **Anthropic**, **OpenAI**, and **Google (Gemini)**.
+
+Set one of the following environment variables to enable LLM-based analysis. The first key found (in the order below) is used:
+
+| Environment Variable | Provider | Default Model |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | Anthropic | `claude-sonnet-4-5` |
+| `OPENAI_API_KEY` | OpenAI | `gpt-4o` |
+| `GEMINI_API_KEY` | Google | `gemini-3-flash-preview` |
+
+Example:
+
+```SHELL
+ANTHROPIC_API_KEY=sk-ant-... plugincheck2 -sourceCodeUri https://github.com/org/repo/tree/v1.0.0 plugin.zip
+```
+
+You can skip individual LLM analyzers with `SKIP_LLM_REVIEW=1` or `SKIP_LLM_CODEDIFF=1`.
+
 ## Security tools
 
 This validator makes uses of the following open source security tools:
@@ -265,7 +285,7 @@ Run "mage gen:readme" to regenerate this section.
 | Changelog (exists) / `changelog` | Ensures a `CHANGELOG.md` file exists within the zip file. | None |
 | Checksum / `checksum` | Validates that the passed checksum (as a validator arg) is the one calculated from the archive file. | `checksum` |
 | Circular Dependencies / `circulardependencies` | Ensures that there aren't any circular dependencies between plugins (`plugin.json`, `dependencies.plugins` field). | None |
-| Code Diff / `codediff` |  | Google API Key with Generative AI access |
+| Code Diff / `codediff` |  | API key for one of: Anthropic (ANTHROPIC_API_KEY), OpenAI (OPENAI_API_KEY), or Google (GEMINI_API_KEY) |
 | Code Rules / `code-rules` | Checks for forbidden access to environment variables, file system or use of syscall module. | [semgrep](https://github.com/returntocorp/semgrep), `sourceCodeUri` |
 | Developer Jargon / `jargon` | Generally discourages use of code jargon in the documentation. | None |
 | Discoverability / `discoverability` | Warns about missing keywords and description that are used for plugin indexing in the catalog. | None |
@@ -275,7 +295,7 @@ Run "mage gen:readme" to regenerate this section.
 | Legacy Grafana Toolkit usage / `legacybuilder` | Detects the usage of the not longer supported Grafana Toolkit. | None |
 | Legacy Platform / `legacyplatform` | Detects use of Angular which is deprecated. | None |
 | License Type / `license` | Checks the declared license is one of: BSD, MIT, Apache 2.0, LGPL3, GPL3, AGPL3. | None |
-| LLM Review / `llmreview` | Runs the code through Gemini LLM to check for security issues or disallowed usage. | Gemini API key |
+| LLM Review / `llmreview` | Runs the code through an LLM to check for security issues or disallowed usage. | API key for one of: Anthropic (ANTHROPIC_API_KEY), OpenAI (OPENAI_API_KEY), or Google (GEMINI_API_KEY) |
 | Logos / `logos` | Detects whether the plugin includes small and large logos to display in the plugin catalog. | None |
 | Manifest (Signing) / `manifest` | When a plugin is signed, the zip file will contain a signed `MANIFEST.txt` file. | None |
 | Metadata / `metadata` | Checks that `plugin.json` exists and is valid. | None |

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Set one of the following environment variables to enable LLM-based analysis. The
 |---|---|---|
 | `ANTHROPIC_API_KEY` | Anthropic | `claude-opus-4-6` |
 | `OPENAI_API_KEY` | OpenAI | `gpt-5.4` |
-| `GEMINI_API_KEY` | Google | `gemini-3-flash-preview` |
+| `GEMINI_API_KEY` | Google | `gemini-3.1-flash-lite-preview` |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ Set one of the following environment variables to enable LLM-based analysis. The
 
 | Environment Variable | Provider | Default Model |
 |---|---|---|
-| `ANTHROPIC_API_KEY` | Anthropic | `claude-sonnet-4-5` |
-| `OPENAI_API_KEY` | OpenAI | `gpt-4o` |
+| `ANTHROPIC_API_KEY` | Anthropic | `claude-opus-4-6` |
+| `OPENAI_API_KEY` | OpenAI | `gpt-5.4` |
 | `GEMINI_API_KEY` | Google | `gemini-3-flash-preview` |
 
 Example:

--- a/pkg/analysis/passes/codediff/codediff.go
+++ b/pkg/analysis/passes/codediff/codediff.go
@@ -91,7 +91,6 @@ var Analyzer = &analysis.Analyzer{
 
 var (
 	agenticClient llmclient.AgenticClient
-	llmCfg        = llmconfig.Resolve()
 )
 
 func SetAgenticClient(client llmclient.AgenticClient) {
@@ -128,6 +127,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
+	llmCfg := llmconfig.Resolve()
 	if llmCfg == nil {
 		logme.Debugln("Skipping LLM code diff analysis: no API key set (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)")
 		return nil, nil
@@ -183,6 +183,7 @@ func run(pass *analysis.Pass) (any, error) {
 
 		// Run LLM analysis
 		answers, err := runLLMAnalysis(
+			llmCfg,
 			versions.SubmittedGitHubVersion.Version,
 			versions.SubmittedGitHubVersion.CommitSHA,
 			versions.CurrentGrafanaVersion.Version,
@@ -294,6 +295,7 @@ func buildQuestionWithContext(question, currentCommit, newCommit string) string 
 }
 
 func runLLMAnalysis(
+	llmCfg *llmconfig.ProviderConfig,
 	newVersion, newCommit, currentVersion, currentCommit, repositoryPath string,
 ) ([]llmclient.AnswerSchema, error) {
 	systemPrompt, err := generateSystemPrompt(newVersion, newCommit, currentVersion, currentCommit)

--- a/pkg/analysis/passes/codediff/codediff.go
+++ b/pkg/analysis/passes/codediff/codediff.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/virusscan"
 	"github.com/grafana/plugin-validator/pkg/llmclient"
+	"github.com/grafana/plugin-validator/pkg/llmconfig"
 	"github.com/grafana/plugin-validator/pkg/logme"
 	"github.com/grafana/plugin-validator/pkg/versioncommitfinder"
 )
@@ -84,16 +85,13 @@ var Analyzer = &analysis.Analyzer{
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "Code Diff",
 		Description:  "",
-		Dependencies: "Google API Key with Generative AI access",
+		Dependencies: "API key for one of: Anthropic (ANTHROPIC_API_KEY), OpenAI (OPENAI_API_KEY), or Google (GEMINI_API_KEY)",
 	},
 }
 
 var (
 	agenticClient llmclient.AgenticClient
-
-	defaultLLMProvider  = "google"
-	defaultLLMModel     = "gemini-3.1-flash-lite-preview"
-	defaultLLMAPIKeyEnv = "GEMINI_API_KEY"
+	llmCfg        = llmconfig.Resolve()
 )
 
 func SetAgenticClient(client llmclient.AgenticClient) {
@@ -130,8 +128,8 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	if os.Getenv(defaultLLMAPIKeyEnv) == "" {
-		logme.Debugln("Skipping LLM code diff analysis:", defaultLLMAPIKeyEnv, "not set")
+	if llmCfg == nil {
+		logme.Debugln("Skipping LLM code diff analysis: no API key set (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)")
 		return nil, nil
 	}
 
@@ -316,9 +314,9 @@ func runLLMAnalysis(
 	client := agenticClient
 	if client == nil {
 		client, err = llmclient.NewAgenticClient(&llmclient.AgenticCallOptions{
-			Provider:     defaultLLMProvider,
-			Model:        defaultLLMModel,
-			APIKey:       os.Getenv(defaultLLMAPIKeyEnv),
+			Provider:     llmCfg.Provider,
+			Model:        llmCfg.Model,
+			APIKey:       llmCfg.APIKey,
 			SystemPrompt: systemPrompt,
 		})
 		if err != nil {

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -28,8 +28,6 @@ import (
 	"github.com/grafana/plugin-validator/pkg/logme"
 )
 
-var llmCfg = llmconfig.Resolve()
-
 var (
 	llmIssueFound    = &analysis.Rule{Name: "llm-issue-found", Severity: analysis.SuspectedProblem}
 	llmReviewSkipped = &analysis.Rule{
@@ -192,6 +190,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
+	llmCfg := llmconfig.Resolve()
 	if llmCfg == nil {
 		logme.Debugln("Skipping LLM review: no API key set (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)")
 		return nil, nil

--- a/pkg/analysis/passes/llmreview/llmreview.go
+++ b/pkg/analysis/passes/llmreview/llmreview.go
@@ -23,11 +23,12 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/trackingscripts"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/unsafesvg"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/virusscan"
+	"github.com/grafana/plugin-validator/pkg/llmconfig"
 	"github.com/grafana/plugin-validator/pkg/llmvalidate"
 	"github.com/grafana/plugin-validator/pkg/logme"
 )
 
-var geminiKey = os.Getenv("GEMINI_API_KEY")
+var llmCfg = llmconfig.Resolve()
 
 var (
 	llmIssueFound    = &analysis.Rule{Name: "llm-issue-found", Severity: analysis.SuspectedProblem}
@@ -70,8 +71,8 @@ var Analyzer = &analysis.Analyzer{
 	Rules:    []*analysis.Rule{llmIssueFound, llmReviewSkipped},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:         "LLM Review",
-		Description:  "Runs the code through Gemini LLM to check for security issues or disallowed usage.",
-		Dependencies: "Gemini API key",
+		Description:  "Runs the code through an LLM to check for security issues or disallowed usage.",
+		Dependencies: "API key for one of: Anthropic (ANTHROPIC_API_KEY), OpenAI (OPENAI_API_KEY), or Google (GEMINI_API_KEY)",
 	},
 }
 
@@ -191,13 +192,14 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	if geminiKey == "" {
+	if llmCfg == nil {
+		logme.Debugln("Skipping LLM review: no API key set (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY)")
 		return nil, nil
 	}
 
-	logme.Debugln("Starting to run Gemini Validations. This might take a while...")
+	logme.DebugFln("Starting LLM review using provider %s (%s). This might take a while...", llmCfg.Provider, llmCfg.Model)
 
-	llmClient, err := llmvalidate.New(context.Background(), "google", "gemini-3-flash-preview", geminiKey)
+	llmClient, err := llmvalidate.New(context.Background(), llmCfg.Provider, llmCfg.Model, llmCfg.APIKey)
 
 	if err != nil {
 		logme.DebugFln("Error initializing llm client: %v", err)
@@ -208,7 +210,7 @@ func run(pass *analysis.Pass) (any, error) {
 	var mandatoryAnswers []llmvalidate.LLMAnswer
 	mandatoryAnswers, err = llmClient.AskLLMAboutCode(sourceCodeDir, Questions, []string{"src", "pkg"})
 	if err != nil {
-		logme.DebugFln("Error getting answers from Gemini LLM for mandatory questions: %v", err)
+		logme.DebugFln("Error getting answers from LLM for mandatory questions: %v", err)
 		return nil, nil
 	}
 
@@ -228,7 +230,7 @@ func run(pass *analysis.Pass) (any, error) {
 	var optionalAnswers []llmvalidate.LLMAnswer
 	optionalAnswers, err = llmClient.AskLLMAboutCode(sourceCodeDir, OptionalQuestions, []string{"src", "pkg"})
 	if err != nil {
-		logme.DebugFln("Error getting answers from Gemini LLM for optional questions: %v", err)
+		logme.DebugFln("Error getting answers from LLM for optional questions: %v", err)
 		return nil, nil
 	}
 

--- a/pkg/llmconfig/llmconfig.go
+++ b/pkg/llmconfig/llmconfig.go
@@ -1,0 +1,37 @@
+package llmconfig
+
+import "os"
+
+// ProviderConfig holds the resolved LLM provider, model, and API key.
+type ProviderConfig struct {
+	Provider string
+	Model    string
+	APIKey   string
+}
+
+// providerDefaults maps each provider to its default model and API key env var.
+var providerDefaults = []struct {
+	EnvVar       string
+	Provider     string
+	DefaultModel string
+}{
+	{"ANTHROPIC_API_KEY", "anthropic", "claude-sonnet-4-5"},
+	{"OPENAI_API_KEY", "openai", "gpt-4o"},
+	{"GEMINI_API_KEY", "google", "gemini-3-flash-preview"},
+}
+
+// Resolve returns the LLM provider configuration by checking environment
+// variables in order: ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY.
+// The first key found wins. Returns nil if no API key is set.
+func Resolve() *ProviderConfig {
+	for _, p := range providerDefaults {
+		if key := os.Getenv(p.EnvVar); key != "" {
+			return &ProviderConfig{
+				Provider: p.Provider,
+				Model:    p.DefaultModel,
+				APIKey:   key,
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/llmconfig/llmconfig.go
+++ b/pkg/llmconfig/llmconfig.go
@@ -15,8 +15,8 @@ var providerDefaults = []struct {
 	Provider     string
 	DefaultModel string
 }{
-	{"ANTHROPIC_API_KEY", "anthropic", "claude-sonnet-4-5"},
-	{"OPENAI_API_KEY", "openai", "gpt-4o"},
+	{"ANTHROPIC_API_KEY", "anthropic", "claude-opus-4-6"},
+	{"OPENAI_API_KEY", "openai", "gpt-5.4"},
 	{"GEMINI_API_KEY", "google", "gemini-3-flash-preview"},
 }
 

--- a/pkg/llmconfig/llmconfig.go
+++ b/pkg/llmconfig/llmconfig.go
@@ -17,7 +17,7 @@ var providerDefaults = []struct {
 }{
 	{"ANTHROPIC_API_KEY", "anthropic", "claude-opus-4-6"},
 	{"OPENAI_API_KEY", "openai", "gpt-5.4"},
-	{"GEMINI_API_KEY", "google", "gemini-3-flash-preview"},
+	{"GEMINI_API_KEY", "google", "gemini-3.1-flash-lite-preview"},
 }
 
 // Resolve returns the LLM provider configuration by checking environment


### PR DESCRIPTION
## Summary
- Add `pkg/llmconfig` package that resolves LLM provider from environment variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) — first key found wins
- Update `llmreview` and `codediff` analyzers to use the shared config instead of hardcoding Google Gemini
- Update README with LLM provider configuration section and updated analyzer table

## Test plan
- [x] Set `ANTHROPIC_API_KEY` and verify `llmreview` and `codediff` use Anthropic
- [x] Set `OPENAI_API_KEY` and verify `llmreview` and `codediff` use OpenAI
- [x] Set `GEMINI_API_KEY` and verify backward compatibility with existing Gemini setup
- [x] Set no API key and verify both analyzers are skipped gracefully
- [x] Set multiple keys and verify priority order (Anthropic > OpenAI > Gemini)