### PR TITLE
Add semgrep test to avoid calling /api/ds/query directly

### DIFF
--- a/pkg/analysis/passes/coderules/coderules_test.go
+++ b/pkg/analysis/passes/coderules/coderules_test.go
@@ -679,3 +679,52 @@ func TestNoDirectCSSImportsGood(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, interceptor.Diagnostics, 0)
 }
+
+func TestNoAPIDsQueryEndpoint(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			sourcecode.Analyzer: filepath.Join("testdata", "api-ds-query-endpoint-bad"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, analysis.Error, interceptor.Diagnostics[0].Severity)
+	require.Equal(
+		t,
+		"Direct frontend usage of '/api/ds/query' is not permitted. Use Grafana runtime APIs getDataSourceSrv().get(...) and then query(...) instead of calling this endpoint directly.",
+		interceptor.Diagnostics[0].Title,
+	)
+	require.Equal(
+		t,
+		"code-rules-no-api-ds-query-endpoint",
+		interceptor.Diagnostics[0].Name,
+	)
+}
+
+func TestNoAPIDsQueryEndpointGood(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			sourcecode.Analyzer: filepath.Join("testdata", "api-ds-query-endpoint-good"),
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}

--- a/pkg/analysis/passes/coderules/semgrep-rules.yaml
+++ b/pkg/analysis/passes/coderules/semgrep-rules.yaml
@@ -331,3 +331,25 @@ rules:
     message: "Direct CSS imports and Emotion UI Global components are not permitted. Use CSS-in-JS solutions like styled-components or emotion's css function instead."
     languages: [javascript, typescript]
     severity: ERROR
+
+  - id: no-api-ds-query-endpoint
+    pattern-either:
+      - pattern-regex: /api/ds/query
+    paths:
+      include:
+        - "src/**/*.ts"
+        - "src/**/*.tsx"
+        - "src/**/*.js"
+        - "src/**/*.jsx"
+      exclude:
+        - "*.spec.ts"
+        - "*.spec.tsx"
+        - "*.test.ts"
+        - "*.test.tsx"
+        - "*.spec.js"
+        - "*.spec.jsx"
+        - "*.test.js"
+        - "*.test.jsx"
+    message: "Direct frontend usage of '/api/ds/query' is not permitted. Use Grafana runtime APIs getDataSourceSrv().get(...) and then query(...) instead of calling this endpoint directly."
+    languages: [javascript, typescript]
+    severity: ERROR

--- a/pkg/analysis/passes/coderules/testdata/api-ds-query-endpoint-bad/src/index.ts
+++ b/pkg/analysis/passes/coderules/testdata/api-ds-query-endpoint-bad/src/index.ts
@@ -1,0 +1,3 @@
+async function runQuery() {
+  return fetch('/api/ds/query', { method: 'POST' });
+}

--- a/pkg/analysis/passes/coderules/testdata/api-ds-query-endpoint-good/src/index.ts
+++ b/pkg/analysis/passes/coderules/testdata/api-ds-query-endpoint-good/src/index.ts
@@ -1,0 +1,7 @@
+import { getDataSourceSrv } from "@grafana/runtime";
+
+async function runQuery() {
+  return getDataSourceSrv()
+    .get("my-datasource")
+    .then((datasource) => datasource.query({}));
+}


### PR DESCRIPTION
This endpoint will eventually go away once `/apis/...` is the only endpoint supported.