### PR TITLE
React19: Add a validator to check plugin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Run "mage gen:readme" to regenerate this section.
 | Plugin Name formatting / `pluginname` | Validates the plugin ID used conforms to our naming convention. | None |
 | Provenance attestation validation / `provenance` | Validates the provenance attestation if the plugin was built with a pipeline supporting provenance attestation (e.g Github Actions). | None |
 | Published / `published-plugin` | Detects whether any version of this plugin exists in the Grafana plugin catalog currently. | None |
-| React 19 Compatibility / `reactcompat` | Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect. | None |
+| React 19 Compatibility / `reactcompat` | Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect. | [npx](https://docs.npmjs.com/cli/v10/commands/npx) |
 | Readme (exists) / `readme` | Ensures a `README.md` file exists within the zip file. | None |
 | Restrictive Dependency / `restrictivedep` | Specifies a valid range of Grafana versions that work with this version of the plugin. | None |
 | Safe Links / `safelinks` | Checks that links from `plugin.json` are safe. | None |

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Run "mage gen:readme" to regenerate this section.
 | Plugin Name formatting / `pluginname` | Validates the plugin ID used conforms to our naming convention. | None |
 | Provenance attestation validation / `provenance` | Validates the provenance attestation if the plugin was built with a pipeline supporting provenance attestation (e.g Github Actions). | None |
 | Published / `published-plugin` | Detects whether any version of this plugin exists in the Grafana plugin catalog currently. | None |
+| React 19 Compatibility / `reactcompat` | Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect. | None |
 | Readme (exists) / `readme` | Ensures a `README.md` file exists within the zip file. | None |
 | Restrictive Dependency / `restrictivedep` | Specifies a valid range of Grafana versions that work with this version of the plugin. | None |
 | Safe Links / `safelinks` | Checks that links from `plugin.json` are safe. | None |

--- a/pkg/analysis/passes/analysis.go
+++ b/pkg/analysis/passes/analysis.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/pluginname"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/provenance"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/published"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/reactcompat"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/readme"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/restrictivedep"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/safelinks"
@@ -90,6 +91,7 @@ var Analyzers = []*analysis.Analyzer{
 	pluginname.Analyzer,
 	provenance.Analyzer,
 	published.Analyzer,
+	reactcompat.Analyzer,
 	readme.Analyzer,
 	restrictivedep.Analyzer,
 	screenshots.Analyzer,

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -120,7 +120,8 @@ func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 	// Dependency issues are intentionally included (no --skipDependencies).
 	args := []string{
 		"-y",
-		"@grafana/react-detect@latest",
+		// Pinned for reproducibility. Bump intentionally when adopting new detection rules.
+		"@grafana/react-detect@0.6.4",
 		"--json",
 		"--distDir", archiveDir,
 		"--skipBuildTooling",

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -2,178 +2,220 @@ package reactcompat
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
-	"regexp"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
-	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
+	"github.com/grafana/plugin-validator/pkg/logme"
 )
-
-const react19UpgradeGuide = "https://react.dev/blog/2024/04/25/react-19-upgrade-guide"
 
 var (
-	react19PropTypes       = &analysis.Rule{Name: "react-19-prop-types", Severity: analysis.Warning}
-	react19LegacyContext   = &analysis.Rule{Name: "react-19-legacy-context", Severity: analysis.Warning}
-	react19StringRefs      = &analysis.Rule{Name: "react-19-string-refs", Severity: analysis.Warning}
-	react19CreateFactory   = &analysis.Rule{Name: "react-19-create-factory", Severity: analysis.Warning}
-	react19FindDOMNode     = &analysis.Rule{Name: "react-19-find-dom-node", Severity: analysis.Warning}
-	react19LegacyRender    = &analysis.Rule{Name: "react-19-legacy-render", Severity: analysis.Warning}
-	react19SecretInternals = &analysis.Rule{Name: "react-19-secret-internals", Severity: analysis.Warning}
-	react19Compatible = &analysis.Rule{Name: "react-19-compatible", Severity: analysis.OK}
+	react19Issue = &analysis.Rule{
+		Name:     "react-19-issue",
+		Severity: analysis.Warning,
+	}
+	react19Compatible = &analysis.Rule{
+		Name:     "react-19-compatible",
+		Severity: analysis.OK,
+	}
 )
 
+// Analyzer checks for React 19 compatibility issues in the plugin bundle by
+// delegating to npx @grafana/react-detect. It silently skips if npx is not
+// available in PATH.
 var Analyzer = &analysis.Analyzer{
 	Name:     "reactcompat",
-	Requires: []*analysis.Analyzer{modulejs.Analyzer},
+	Requires: []*analysis.Analyzer{archive.Analyzer},
 	Run:      run,
-	Rules: []*analysis.Rule{
-		react19PropTypes,
-		react19LegacyContext,
-		react19StringRefs,
-		react19CreateFactory,
-		react19FindDOMNode,
-		react19LegacyRender,
-		react19SecretInternals,
-		react19Compatible,
-	},
+	Rules:    []*analysis.Rule{react19Issue, react19Compatible},
 	ReadmeInfo: analysis.ReadmeInfo{
 		Name:        "React 19 Compatibility",
-		Description: "Detects usage of React APIs removed or deprecated in React 19.",
+		Description: "Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect.",
 	},
 }
 
-// detector checks a single module.js file for a specific pattern.
-type detector interface {
-	Detect(moduleJs []byte) bool
-	Pattern() string
+// reactDetectOutput is the top-level JSON structure emitted by @grafana/react-detect.
+type reactDetectOutput struct {
+	SourceCodeIssues map[string][]sourceCodeIssue `json:"sourceCodeIssues"`
+	DependencyIssues []dependencyIssue            `json:"dependencyIssues"`
 }
 
-type containsBytesDetector struct {
-	pattern []byte
+type sourceCodeIssue struct {
+	Pattern  string   `json:"pattern"`
+	Severity string   `json:"severity"`
+	Location location `json:"location"`
+	Problem  string   `json:"problem"`
+	Fix      fix      `json:"fix"`
+	Link     string   `json:"link"`
 }
 
-func (d *containsBytesDetector) Detect(moduleJs []byte) bool {
-	return bytes.Contains(moduleJs, d.pattern)
+type location struct {
+	File   string `json:"file"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
 }
 
-func (d *containsBytesDetector) Pattern() string {
-	return string(d.pattern)
+type fix struct {
+	Description string `json:"description"`
 }
 
-type regexDetector struct {
-	regex *regexp.Regexp
+type dependencyIssue struct {
+	Pattern      string   `json:"pattern"`
+	Severity     string   `json:"severity"`
+	Problem      string   `json:"problem"`
+	Link         string   `json:"link"`
+	PackageNames []string `json:"packageNames"`
 }
 
-func (d *regexDetector) Detect(moduleJs []byte) bool {
-	return d.regex.Match(moduleJs)
-}
-
-func (d *regexDetector) Pattern() string {
-	return d.regex.String()
-}
-
-// reactPattern groups a rule, a human-readable description, and the detectors that trigger it.
-type reactPattern struct {
-	rule        *analysis.Rule
-	title       string
-	description string
-	detectors   []detector
-}
-
-var reactPatterns = []reactPattern{
-	{
-		rule:        react19PropTypes,
-		title:       "module.js: Uses removed React API propTypes or defaultProps",
-		description: "Detected usage of '%s'. propTypes and defaultProps on function components were removed in React 19.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte(".propTypes=")},
-			&containsBytesDetector{pattern: []byte(".defaultProps=")},
-		},
-	},
-	{
-		rule:        react19LegacyContext,
-		title:       "module.js: Uses removed React legacy context API",
-		description: "Detected usage of '%s'. contextTypes, childContextTypes, and getChildContext were removed in React 19.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte(".contextTypes=")},
-			&containsBytesDetector{pattern: []byte(".childContextTypes=")},
-			&containsBytesDetector{pattern: []byte("getChildContext")},
-		},
-	},
-	{
-		rule:        react19StringRefs,
-		title:       "module.js: Uses removed React string refs",
-		description: "Detected usage of '%s'. String refs were removed in React 19. Use callback refs or React.createRef() instead.",
-		detectors: []detector{
-			&regexDetector{regex: regexp.MustCompile(`ref:"[^"]+?"`)},
-			&regexDetector{regex: regexp.MustCompile(`ref:'[^']+'`)},
-		},
-	},
-	{
-		rule:        react19CreateFactory,
-		title:       "module.js: Uses removed React.createFactory",
-		description: "Detected usage of '%s'. React.createFactory was removed in React 19. Use JSX instead.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte("createFactory(")},
-		},
-	},
-	{
-		rule:        react19FindDOMNode,
-		title:       "module.js: Uses removed ReactDOM.findDOMNode",
-		description: "Detected usage of '%s'. ReactDOM.findDOMNode was removed in React 19. Use DOM refs instead.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte("findDOMNode(")},
-		},
-	},
-	{
-		rule:        react19LegacyRender,
-		title:       "module.js: Uses removed ReactDOM.render or unmountComponentAtNode",
-		description: "Detected usage of '%s'. ReactDOM.render and unmountComponentAtNode were removed in React 19. Use createRoot instead.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte("ReactDOM.render(")},
-			&containsBytesDetector{pattern: []byte("unmountComponentAtNode(")},
-		},
-	},
-	{
-		rule:        react19SecretInternals,
-		title:       "module.js: Uses React internal __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
-		description: "Detected usage of '%s'. This internal was removed in React 19.",
-		detectors: []detector{
-			&containsBytesDetector{pattern: []byte("__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED")},
-		},
-	},
-}
-
-func run(pass *analysis.Pass) (interface{}, error) {
-	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
-	if !ok || len(moduleJsMap) == 0 {
+func run(pass *analysis.Pass) (any, error) {
+	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
+	if !ok || archiveDir == "" {
 		return nil, nil
 	}
 
-	for _, pattern := range reactPatterns {
-		matched := false
-		matchedPattern := ""
+	npxPath, err := exec.LookPath("npx")
+	if err != nil {
+		logme.DebugFln("npx not found in PATH, skipping react-detect")
+		return nil, nil
+	}
+	logme.DebugFln("npx path: %s", npxPath)
 
-	outer:
-		for _, content := range moduleJsMap {
-			for _, d := range pattern.detectors {
-				if d.Detect(content) {
-					matched = true
-					matchedPattern = d.Pattern()
-					break outer
-				}
-			}
-		}
+	tmpDir, cleanup, err := prepareTmpDir(archiveDir)
+	if err != nil {
+		logme.DebugFln("failed to prepare temp dir for react-detect: %v", err)
+		return nil, nil
+	}
+	defer cleanup()
 
-		if matched {
-			pass.ReportResult(
-				pass.AnalyzerName,
-				pattern.rule,
-				pattern.title,
-				fmt.Sprintf(pattern.description+" See: "+react19UpgradeGuide, matchedPattern),
-			)
-		}
+	output, err := runReactDetect(npxPath, tmpDir)
+	if err != nil {
+		logme.DebugFln("react-detect failed: %v", err)
+		return nil, nil
+	}
+
+	issueCount := reportIssues(pass, output)
+
+	if issueCount == 0 && react19Compatible.ReportAll {
+		pass.ReportResult(
+			pass.AnalyzerName,
+			react19Compatible,
+			"Plugin is compatible with React 19",
+			"No React 19 compatibility issues were detected.",
+		)
 	}
 
 	return nil, nil
+}
+
+// prepareTmpDir creates a temporary directory with a dist/ symlink pointing at
+// archiveDir. react-detect expects the plugin files to live under dist/.
+// The returned cleanup function removes the temp directory.
+func prepareTmpDir(archiveDir string) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "reactcompat-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	cleanup := func() { os.RemoveAll(tmpDir) }
+
+	distLink := filepath.Join(tmpDir, "dist")
+	if err := os.Symlink(archiveDir, distLink); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("create dist symlink: %w", err)
+	}
+
+	return tmpDir, cleanup, nil
+}
+
+// runReactDetect shells out to react-detect and returns the parsed output.
+func runReactDetect(npxPath, pluginRoot string) (*reactDetectOutput, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// --json: machine-readable output. --skipBuildTooling: avoid running bundlers.
+	// --noErrorExitCode: always exit 0 so we can parse partial output on warnings.
+	// Dependency issues are intentionally included (no --skipDependencies).
+	args := []string{
+		"-y",
+		"@grafana/react-detect@latest",
+		"--json",
+		"--pluginRoot", pluginRoot,
+		"--skipBuildTooling",
+		"--noErrorExitCode",
+	}
+	logme.DebugFln("running react-detect with args: %v", args)
+
+	cmd := exec.CommandContext(ctx, npxPath, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("react-detect exited with error: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return parseResults(out)
+}
+
+// parseResults unmarshals the raw JSON bytes from react-detect.
+func parseResults(data []byte) (*reactDetectOutput, error) {
+	var output reactDetectOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, fmt.Errorf("parse react-detect output: %w", err)
+	}
+	return &output, nil
+}
+
+// reportIssues translates the react-detect output into pass diagnostics and
+// returns the total number of issues reported.
+func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
+	if react19Issue.Disabled {
+		return 0
+	}
+
+	if output == nil {
+		return 0
+	}
+
+	count := 0
+
+	for _, issues := range output.SourceCodeIssues {
+		for _, issue := range issues {
+			rule := &analysis.Rule{
+				Name:     fmt.Sprintf("react-19-%s", issue.Pattern),
+				Severity: analysis.Warning,
+			}
+			detail := fmt.Sprintf(
+				"Detected in %s at line %d. %s See: %s",
+				issue.Location.File,
+				issue.Location.Line,
+				issue.Fix.Description,
+				issue.Link,
+			)
+			pass.ReportResult(pass.AnalyzerName, rule, issue.Problem, detail)
+			count++
+		}
+	}
+
+	for _, issue := range output.DependencyIssues {
+		rule := &analysis.Rule{
+			Name:     fmt.Sprintf("react-19-dep-%s", issue.Pattern),
+			Severity: analysis.Warning,
+		}
+		detail := fmt.Sprintf(
+			"Affected packages: %s. See: %s",
+			strings.Join(issue.PackageNames, ", "),
+			issue.Link,
+		)
+		pass.ReportResult(pass.AnalyzerName, rule, issue.Problem, detail)
+		count++
+	}
+
+	return count
 }

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -35,8 +35,9 @@ var Analyzer = &analysis.Analyzer{
 	Run:      run,
 	Rules:    []*analysis.Rule{react19Issue, react19Compatible},
 	ReadmeInfo: analysis.ReadmeInfo{
-		Name:        "React 19 Compatibility",
-		Description: "Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect.",
+		Name:         "React 19 Compatibility",
+		Description:  "Detects usage of React APIs removed or deprecated in React 19 using @grafana/react-detect.",
+		Dependencies: "[npx](https://docs.npmjs.com/cli/v10/commands/npx)",
 	},
 }
 
@@ -131,6 +132,9 @@ func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
+	if stderr.Len() > 0 {
+		logme.DebugFln("react-detect stderr: %s", stderr.String())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("react-detect exited with error: %w (stderr: %s)", err, stderr.String())
 	}

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -27,8 +27,8 @@ var (
 )
 
 // Analyzer checks for React 19 compatibility issues in the plugin bundle by
-// delegating to npx @grafana/react-detect. If npx is not available or
-// react-detect fails, a warning diagnostic is emitted explaining the skip.
+// delegating to npx @grafana/react-detect. Silently skips if npx is not in PATH.
+// If react-detect is found but fails, a warning diagnostic is emitted.
 var Analyzer = &analysis.Analyzer{
 	Name:     "reactcompat",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
@@ -82,13 +82,9 @@ func run(pass *analysis.Pass) (any, error) {
 
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
+		// npx not in PATH is expected in environments without Node.js (e.g. Docker builder).
+		// Only log at debug level — not a failure, just an unavailable optional check.
 		logme.DebugFln("npx not found in PATH, skipping react-detect")
-		pass.ReportResult(
-			pass.AnalyzerName,
-			react19Issue,
-			"React 19 compatibility: skipped (npx not found in PATH)",
-			"Install Node.js and npx to enable React 19 compatibility checks.",
-		)
 		return nil, nil
 	}
 	logme.DebugFln("npx path: %s", npxPath)

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -180,7 +180,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 				issue.Fix.Description,
 				issue.Link,
 			)
-			pass.ReportResult(pass.AnalyzerName, rule, issue.Problem, detail)
+			pass.ReportResult(pass.AnalyzerName, rule, "React 19 compatibility: "+issue.Problem, detail)
 			count++
 		}
 	}
@@ -195,7 +195,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 			strings.Join(issue.PackageNames, ", "),
 			issue.Link,
 		)
-		pass.ReportResult(pass.AnalyzerName, rule, issue.Problem, detail)
+		pass.ReportResult(pass.AnalyzerName, rule, "React 19 compatibility: "+issue.Problem, detail)
 		count++
 	}
 

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -175,7 +175,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 		for _, issue := range output.SourceCodeIssues[pattern] {
 			rule := &analysis.Rule{
 				Name:     fmt.Sprintf("react-19-%s", issue.Pattern),
-				Severity: analysis.Warning,
+				Severity: react19Issue.Severity,
 			}
 			detail := fmt.Sprintf(
 				"Detected in %s at line %d. %s See: %s Note: this may be a false positive.",
@@ -192,7 +192,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 	for _, issue := range output.DependencyIssues {
 		rule := &analysis.Rule{
 			Name:     fmt.Sprintf("react-19-dep-%s", issue.Pattern),
-			Severity: analysis.Warning,
+			Severity: react19Issue.Severity,
 		}
 		detail := fmt.Sprintf(
 			"Affected packages: %s. See: %s Note: this may be a false positive.",

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -88,14 +86,7 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 	logme.DebugFln("npx path: %s", npxPath)
 
-	tmpDir, cleanup, err := prepareTmpDir(archiveDir)
-	if err != nil {
-		logme.DebugFln("failed to prepare temp dir for react-detect: %v", err)
-		return nil, nil
-	}
-	defer cleanup()
-
-	output, err := runReactDetect(npxPath, tmpDir)
+	output, err := runReactDetect(npxPath, archiveDir)
 	if err != nil {
 		logme.DebugFln("react-detect failed: %v", err)
 		return nil, nil
@@ -115,40 +106,22 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// prepareTmpDir creates a temporary directory with a dist/ symlink pointing at
-// archiveDir. The extracted archive has files at the root (module.js, plugin.json,
-// etc.) but react-detect expects them under a dist/ subdirectory.
-// The returned cleanup function removes the temp directory.
-func prepareTmpDir(archiveDir string) (string, func(), error) {
-	tmpDir, err := os.MkdirTemp("", "reactcompat-*")
-	if err != nil {
-		return "", nil, fmt.Errorf("create temp dir: %w", err)
-	}
-
-	cleanup := func() { os.RemoveAll(tmpDir) }
-
-	distLink := filepath.Join(tmpDir, "dist")
-	if err := os.Symlink(archiveDir, distLink); err != nil {
-		cleanup()
-		return "", nil, fmt.Errorf("create dist symlink: %w", err)
-	}
-
-	return tmpDir, cleanup, nil
-}
-
 // runReactDetect shells out to react-detect and returns the parsed output.
-func runReactDetect(npxPath, pluginRoot string) (*reactDetectOutput, error) {
+// --distDir points react-detect directly at the extracted archive directory,
+// avoiding the need for a symlink or temp directory.
+func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// --json: machine-readable output. --skipBuildTooling: avoid running bundlers.
 	// --noErrorExitCode: always exit 0 so we can parse partial output on warnings.
+	// --distDir: point at the extracted archive directly (available since v0.6.4).
 	// Dependency issues are intentionally included (no --skipDependencies).
 	args := []string{
 		"-y",
 		"@grafana/react-detect@latest",
 		"--json",
-		"--pluginRoot", pluginRoot,
+		"--distDir", archiveDir,
 		"--skipBuildTooling",
 		"--noErrorExitCode",
 	}

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -1,0 +1,179 @@
+package reactcompat
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+)
+
+const react19UpgradeGuide = "https://react.dev/blog/2024/04/25/react-19-upgrade-guide"
+
+var (
+	react19PropTypes       = &analysis.Rule{Name: "react-19-prop-types", Severity: analysis.Warning}
+	react19LegacyContext   = &analysis.Rule{Name: "react-19-legacy-context", Severity: analysis.Warning}
+	react19StringRefs      = &analysis.Rule{Name: "react-19-string-refs", Severity: analysis.Warning}
+	react19CreateFactory   = &analysis.Rule{Name: "react-19-create-factory", Severity: analysis.Warning}
+	react19FindDOMNode     = &analysis.Rule{Name: "react-19-find-dom-node", Severity: analysis.Warning}
+	react19LegacyRender    = &analysis.Rule{Name: "react-19-legacy-render", Severity: analysis.Warning}
+	react19SecretInternals = &analysis.Rule{Name: "react-19-secret-internals", Severity: analysis.Warning}
+	react19Compatible = &analysis.Rule{Name: "react-19-compatible", Severity: analysis.OK}
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "reactcompat",
+	Requires: []*analysis.Analyzer{modulejs.Analyzer},
+	Run:      run,
+	Rules: []*analysis.Rule{
+		react19PropTypes,
+		react19LegacyContext,
+		react19StringRefs,
+		react19CreateFactory,
+		react19FindDOMNode,
+		react19LegacyRender,
+		react19SecretInternals,
+		react19Compatible,
+	},
+	ReadmeInfo: analysis.ReadmeInfo{
+		Name:        "React 19 Compatibility",
+		Description: "Detects usage of React APIs removed or deprecated in React 19.",
+	},
+}
+
+// detector checks a single module.js file for a specific pattern.
+type detector interface {
+	Detect(moduleJs []byte) bool
+	Pattern() string
+}
+
+type containsBytesDetector struct {
+	pattern []byte
+}
+
+func (d *containsBytesDetector) Detect(moduleJs []byte) bool {
+	return bytes.Contains(moduleJs, d.pattern)
+}
+
+func (d *containsBytesDetector) Pattern() string {
+	return string(d.pattern)
+}
+
+type regexDetector struct {
+	regex *regexp.Regexp
+}
+
+func (d *regexDetector) Detect(moduleJs []byte) bool {
+	return d.regex.Match(moduleJs)
+}
+
+func (d *regexDetector) Pattern() string {
+	return d.regex.String()
+}
+
+// reactPattern groups a rule, a human-readable description, and the detectors that trigger it.
+type reactPattern struct {
+	rule        *analysis.Rule
+	title       string
+	description string
+	detectors   []detector
+}
+
+var reactPatterns = []reactPattern{
+	{
+		rule:        react19PropTypes,
+		title:       "module.js: Uses removed React API propTypes or defaultProps",
+		description: "Detected usage of '%s'. propTypes and defaultProps on function components were removed in React 19.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte(".propTypes=")},
+			&containsBytesDetector{pattern: []byte(".defaultProps=")},
+		},
+	},
+	{
+		rule:        react19LegacyContext,
+		title:       "module.js: Uses removed React legacy context API",
+		description: "Detected usage of '%s'. contextTypes, childContextTypes, and getChildContext were removed in React 19.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte(".contextTypes=")},
+			&containsBytesDetector{pattern: []byte(".childContextTypes=")},
+			&containsBytesDetector{pattern: []byte("getChildContext")},
+		},
+	},
+	{
+		rule:        react19StringRefs,
+		title:       "module.js: Uses removed React string refs",
+		description: "Detected usage of '%s'. String refs were removed in React 19. Use callback refs or React.createRef() instead.",
+		detectors: []detector{
+			&regexDetector{regex: regexp.MustCompile(`ref:"[^"]+?"`)},
+			&regexDetector{regex: regexp.MustCompile(`ref:'[^']+'`)},
+		},
+	},
+	{
+		rule:        react19CreateFactory,
+		title:       "module.js: Uses removed React.createFactory",
+		description: "Detected usage of '%s'. React.createFactory was removed in React 19. Use JSX instead.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte("createFactory(")},
+		},
+	},
+	{
+		rule:        react19FindDOMNode,
+		title:       "module.js: Uses removed ReactDOM.findDOMNode",
+		description: "Detected usage of '%s'. ReactDOM.findDOMNode was removed in React 19. Use DOM refs instead.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte("findDOMNode(")},
+		},
+	},
+	{
+		rule:        react19LegacyRender,
+		title:       "module.js: Uses removed ReactDOM.render or unmountComponentAtNode",
+		description: "Detected usage of '%s'. ReactDOM.render and unmountComponentAtNode were removed in React 19. Use createRoot instead.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte("ReactDOM.render(")},
+			&containsBytesDetector{pattern: []byte("unmountComponentAtNode(")},
+		},
+	},
+	{
+		rule:        react19SecretInternals,
+		title:       "module.js: Uses React internal __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
+		description: "Detected usage of '%s'. This internal was removed in React 19.",
+		detectors: []detector{
+			&containsBytesDetector{pattern: []byte("__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED")},
+		},
+	},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	moduleJsMap, ok := pass.ResultOf[modulejs.Analyzer].(map[string][]byte)
+	if !ok || len(moduleJsMap) == 0 {
+		return nil, nil
+	}
+
+	for _, pattern := range reactPatterns {
+		matched := false
+		matchedPattern := ""
+
+	outer:
+		for _, content := range moduleJsMap {
+			for _, d := range pattern.detectors {
+				if d.Detect(content) {
+					matched = true
+					matchedPattern = d.Pattern()
+					break outer
+				}
+			}
+		}
+
+		if matched {
+			pass.ReportResult(
+				pass.AnalyzerName,
+				pattern.rule,
+				pattern.title,
+				fmt.Sprintf(pattern.description+" See: "+react19UpgradeGuide, matchedPattern),
+			)
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -115,7 +116,8 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 // prepareTmpDir creates a temporary directory with a dist/ symlink pointing at
-// archiveDir. react-detect expects the plugin files to live under dist/.
+// archiveDir. The extracted archive has files at the root (module.js, plugin.json,
+// etc.) but react-detect expects them under a dist/ subdirectory.
 // The returned cleanup function removes the temp directory.
 func prepareTmpDir(archiveDir string) (string, func(), error) {
 	tmpDir, err := os.MkdirTemp("", "reactcompat-*")
@@ -175,6 +177,7 @@ func parseResults(data []byte) (*reactDetectOutput, error) {
 // reportIssues translates the react-detect output into pass diagnostics and
 // returns the total number of issues reported.
 func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
+	// react19Issue serves as the config gate for all dynamic react-19 rules.
 	if react19Issue.Disabled {
 		return 0
 	}
@@ -185,14 +188,20 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 
 	count := 0
 
-	for _, issues := range output.SourceCodeIssues {
-		for _, issue := range issues {
+	patterns := make([]string, 0, len(output.SourceCodeIssues))
+	for p := range output.SourceCodeIssues {
+		patterns = append(patterns, p)
+	}
+	slices.Sort(patterns)
+
+	for _, pattern := range patterns {
+		for _, issue := range output.SourceCodeIssues[pattern] {
 			rule := &analysis.Rule{
 				Name:     fmt.Sprintf("react-19-%s", issue.Pattern),
 				Severity: analysis.Warning,
 			}
 			detail := fmt.Sprintf(
-				"Detected in %s at line %d. %s See: %s",
+				"Detected in %s at line %d. %s See: %s Note: this may be a false positive.",
 				issue.Location.File,
 				issue.Location.Line,
 				issue.Fix.Description,
@@ -209,7 +218,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 			Severity: analysis.Warning,
 		}
 		detail := fmt.Sprintf(
-			"Affected packages: %s. See: %s",
+			"Affected packages: %s. See: %s Note: this may be a false positive.",
 			strings.Join(issue.PackageNames, ", "),
 			issue.Link,
 		)

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -28,7 +28,7 @@ var (
 
 // Analyzer checks for React 19 compatibility issues in the plugin bundle by
 // delegating to npx @grafana/react-detect. It silently skips if npx is not
-// available in PATH.
+// available in PATH, or if react-detect fails to run or returns unparseable output.
 var Analyzer = &analysis.Analyzer{
 	Name:     "reactcompat",
 	Requires: []*analysis.Analyzer{archive.Analyzer},

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -27,8 +27,8 @@ var (
 )
 
 // Analyzer checks for React 19 compatibility issues in the plugin bundle by
-// delegating to npx @grafana/react-detect. It silently skips if npx is not
-// available in PATH, or if react-detect fails to run or returns unparseable output.
+// delegating to npx @grafana/react-detect. If npx is not available or
+// react-detect fails, a warning diagnostic is emitted explaining the skip.
 var Analyzer = &analysis.Analyzer{
 	Name:     "reactcompat",
 	Requires: []*analysis.Analyzer{archive.Analyzer},
@@ -83,6 +83,12 @@ func run(pass *analysis.Pass) (any, error) {
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
 		logme.DebugFln("npx not found in PATH, skipping react-detect")
+		pass.ReportResult(
+			pass.AnalyzerName,
+			react19Issue,
+			"React 19 compatibility: skipped (npx not found in PATH)",
+			"Install Node.js and npx to enable React 19 compatibility checks.",
+		)
 		return nil, nil
 	}
 	logme.DebugFln("npx path: %s", npxPath)
@@ -90,6 +96,12 @@ func run(pass *analysis.Pass) (any, error) {
 	output, err := runReactDetect(npxPath, archiveDir)
 	if err != nil {
 		logme.DebugFln("react-detect failed: %v", err)
+		pass.ReportResult(
+			pass.AnalyzerName,
+			react19Issue,
+			"React 19 compatibility: skipped (react-detect failed)",
+			fmt.Sprintf("react-detect could not be executed: %v", err),
+		)
 		return nil, nil
 	}
 

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -15,6 +15,10 @@ import (
 	"github.com/grafana/plugin-validator/pkg/logme"
 )
 
+// reactDetectVersion is the pinned version of @grafana/react-detect.
+// Bump intentionally when adopting new detection rules.
+const reactDetectVersion = "0.6.4"
+
 var (
 	react19Issue = &analysis.Rule{
 		Name:     "react-19-issue",
@@ -128,8 +132,7 @@ func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 	// Dependency issues are intentionally included (no --skipDependencies).
 	args := []string{
 		"-y",
-		// Pinned for reproducibility. Bump intentionally when adopting new detection rules.
-		"@grafana/react-detect@0.6.4",
+		"@grafana/react-detect@" + reactDetectVersion,
 		"--json",
 		"--distDir", archiveDir,
 		"--skipBuildTooling",

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -1,267 +1,272 @@
 package reactcompat
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
-	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/archive"
 	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
 )
 
-func newPass(interceptor *testpassinterceptor.TestPassInterceptor, content map[string][]byte) *analysis.Pass {
+func newPass(interceptor *testpassinterceptor.TestPassInterceptor, archiveDir string) *analysis.Pass {
 	return &analysis.Pass{
-		RootDir: filepath.Join("./"),
+		AnalyzerName: "reactcompat",
+		RootDir:      filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: content,
+			archive.Analyzer: archiveDir,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
 }
 
-func TestCleanPlugin(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`),
-	})
+// TestParseResults verifies that a valid JSON payload is correctly decoded and
+// mapped to the expected diagnostics.
+func TestParseResults(t *testing.T) {
+	jsonPayload := []byte(`{
+		"sourceCodeIssues": {
+			"usePropTypes": [
+				{
+					"pattern": "usePropTypes",
+					"severity": "critical",
+					"location": {"type": "source-map", "file": "module.js", "line": 42, "column": 10},
+					"problem": "Uses deprecated propTypes",
+					"fix": {"description": "Remove propTypes usage."},
+					"link": "https://react.dev/blog/2024/04/25/react-19-upgrade-guide"
+				}
+			]
+		},
+		"dependencyIssues": [
+			{
+				"pattern": "oldReactDom",
+				"severity": "critical",
+				"problem": "Depends on old react-dom",
+				"link": "https://example.com",
+				"packageNames": ["react-dom", "react"]
+			}
+		]
+	}`)
 
-	_, err := Analyzer.Run(pass)
+	output, err := parseResults(jsonPayload)
 	require.NoError(t, err)
-	// No warnings; the OK rule only fires when ReportAll is set.
+	require.Len(t, output.SourceCodeIssues, 1)
+	require.Len(t, output.SourceCodeIssues["usePropTypes"], 1)
+	require.Len(t, output.DependencyIssues, 1)
+
+	sc := output.SourceCodeIssues["usePropTypes"][0]
+	require.Equal(t, "usePropTypes", sc.Pattern)
+	require.Equal(t, "module.js", sc.Location.File)
+	require.Equal(t, 42, sc.Location.Line)
+	require.Equal(t, "Uses deprecated propTypes", sc.Problem)
+	require.Equal(t, "Remove propTypes usage.", sc.Fix.Description)
+	require.Equal(t, "https://react.dev/blog/2024/04/25/react-19-upgrade-guide", sc.Link)
+
+	dep := output.DependencyIssues[0]
+	require.Equal(t, "oldReactDom", dep.Pattern)
+	require.Equal(t, []string{"react-dom", "react"}, dep.PackageNames)
+}
+
+// TestParseResultsEmpty verifies that a payload with no issues produces an
+// empty but non-nil result.
+func TestParseResultsEmpty(t *testing.T) {
+	jsonPayload := []byte(`{"sourceCodeIssues": {}, "dependencyIssues": []}`)
+
+	output, err := parseResults(jsonPayload)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.Len(t, output.SourceCodeIssues, 0)
+	require.Len(t, output.DependencyIssues, 0)
+}
+
+// TestParseResultsMalformed verifies that garbage input returns an error rather
+// than a panic or silent zero value.
+func TestParseResultsMalformed(t *testing.T) {
+	_, err := parseResults([]byte(`not valid json {{{`))
+	require.Error(t, err)
+}
+
+// TestReportIssuesSourceCode verifies correct diagnostic generation for source
+// code issues.
+func TestReportIssuesSourceCode(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, "/some/archive/dir")
+
+	output := &reactDetectOutput{
+		SourceCodeIssues: map[string][]sourceCodeIssue{
+			"usePropTypes": {
+				{
+					Pattern:  "usePropTypes",
+					Severity: "critical",
+					Location: location{File: "module.js", Line: 10, Column: 5},
+					Problem:  "Uses deprecated propTypes",
+					Fix:      fix{Description: "Remove propTypes."},
+					Link:     "https://react.dev/upgrade",
+				},
+			},
+		},
+	}
+
+	count := reportIssues(pass, output)
+	require.Equal(t, 1, count)
+	require.Len(t, interceptor.Diagnostics, 1)
+
+	d := interceptor.Diagnostics[0]
+	require.Equal(t, "react-19-usePropTypes", d.Name)
+	require.Equal(t, analysis.Warning, d.Severity)
+	require.Equal(t, "Uses deprecated propTypes", d.Title)
+	require.Contains(t, d.Detail, "module.js")
+	require.Contains(t, d.Detail, "10")
+	require.Contains(t, d.Detail, "Remove propTypes.")
+	require.Contains(t, d.Detail, "https://react.dev/upgrade")
+}
+
+// TestReportIssuesDependency verifies correct diagnostic generation for
+// dependency issues.
+func TestReportIssuesDependency(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, "/some/archive/dir")
+
+	output := &reactDetectOutput{
+		DependencyIssues: []dependencyIssue{
+			{
+				Pattern:      "oldReactDom",
+				Severity:     "critical",
+				Problem:      "Depends on old react-dom",
+				Link:         "https://example.com/fix",
+				PackageNames: []string{"react-dom", "react"},
+			},
+		},
+	}
+
+	count := reportIssues(pass, output)
+	require.Equal(t, 1, count)
+	require.Len(t, interceptor.Diagnostics, 1)
+
+	d := interceptor.Diagnostics[0]
+	require.Equal(t, "react-19-dep-oldReactDom", d.Name)
+	require.Equal(t, analysis.Warning, d.Severity)
+	require.Equal(t, "Depends on old react-dom", d.Title)
+	require.Contains(t, d.Detail, "react-dom, react")
+	require.Contains(t, d.Detail, "https://example.com/fix")
+}
+
+// TestReportIssuesNil verifies that a nil output produces no diagnostics.
+func TestReportIssuesNil(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, "/some/archive/dir")
+
+	count := reportIssues(pass, nil)
+	require.Equal(t, 0, count)
 	require.Len(t, interceptor.Diagnostics, 0)
 }
 
-func TestNoModuleJs(t *testing.T) {
+// TestPrepareTmpDir verifies that prepareTmpDir creates the expected symlink
+// and that the cleanup function removes the directory.
+func TestPrepareTmpDir(t *testing.T) {
+	archiveDir := t.TempDir()
+
+	tmpDir, cleanup, err := prepareTmpDir(archiveDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, tmpDir)
+
+	distLink := filepath.Join(tmpDir, "dist")
+	target, err := os.Readlink(distLink)
+	require.NoError(t, err)
+	require.Equal(t, archiveDir, target)
+
+	cleanup()
+
+	_, statErr := os.Stat(tmpDir)
+	require.True(t, os.IsNotExist(statErr), "temp dir should be removed after cleanup")
+}
+
+// TestNpxNotAvailable verifies that the analyzer silently skips (nil, nil) when
+// npx is not found in PATH, producing no diagnostics.
+func TestNpxNotAvailable(t *testing.T) {
+	if _, err := exec.LookPath("npx"); err == nil {
+		t.Skip("npx is available in this environment; skipping npx-not-found test")
+	}
+
+	archiveDir := t.TempDir()
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, archiveDir)
+
+	result, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+// TestReportIssuesCombined verifies that multiple source code issue groups and a
+// dependency issue are all counted and reported correctly in a single call.
+func TestReportIssuesCombined(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, "/some/archive/dir")
+
+	output := &reactDetectOutput{
+		SourceCodeIssues: map[string][]sourceCodeIssue{
+			"usePropTypes": {
+				{
+					Pattern:  "usePropTypes",
+					Severity: "critical",
+					Location: location{File: "module.js", Line: 10, Column: 5},
+					Problem:  "Uses deprecated propTypes",
+					Fix:      fix{Description: "Remove propTypes."},
+					Link:     "https://react.dev/upgrade",
+				},
+			},
+			"findDOMNode": {
+				{
+					Pattern:  "findDOMNode",
+					Severity: "critical",
+					Location: location{File: "other.js", Line: 20, Column: 3},
+					Problem:  "Uses removed findDOMNode",
+					Fix:      fix{Description: "Use a ref instead."},
+					Link:     "https://react.dev/upgrade#finddomnode",
+				},
+			},
+		},
+		DependencyIssues: []dependencyIssue{
+			{
+				Pattern:      "oldReactDom",
+				Severity:     "critical",
+				Problem:      "Depends on old react-dom",
+				Link:         "https://example.com/fix",
+				PackageNames: []string{"react-dom"},
+			},
+		},
+	}
+
+	count := reportIssues(pass, output)
+	require.Equal(t, 3, count)
+	require.Len(t, interceptor.Diagnostics, 3)
+
+	ruleNames := make([]string, 0, 3)
+	for _, d := range interceptor.Diagnostics {
+		ruleNames = append(ruleNames, d.Name)
+	}
+	require.Contains(t, ruleNames, "react-19-usePropTypes")
+	require.Contains(t, ruleNames, "react-19-findDOMNode")
+	require.Contains(t, ruleNames, "react-19-dep-oldReactDom")
+}
+
+// TestNoArchiveDir verifies that a missing archive result produces no diagnostics.
+func TestNoArchiveDir(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pass := &analysis.Pass{
 		RootDir: filepath.Join("./"),
 		ResultOf: map[*analysis.Analyzer]interface{}{
-			modulejs.Analyzer: map[string][]byte{},
+			archive.Analyzer: nil,
 		},
 		Report: interceptor.ReportInterceptor(),
 	}
 
-	_, err := Analyzer.Run(pass)
+	result, err := Analyzer.Run(pass)
 	require.NoError(t, err)
+	require.Nil(t, result)
 	require.Len(t, interceptor.Diagnostics, 0)
-}
-
-func TestPropTypes(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.propTypes={name:PropTypes.string}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
-	require.Equal(t, analysis.Warning, interceptor.Diagnostics[0].Severity)
-}
-
-func TestDefaultProps(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.defaultProps={name:"default"}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
-}
-
-func TestContextTypes(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.contextTypes={theme:PropTypes.object}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
-}
-
-func TestChildContextTypes(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.childContextTypes={theme:PropTypes.object}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
-}
-
-func TestGetChildContext(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`getChildContext(){return{theme:this.state.theme}}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
-}
-
-func TestStringRefsDoubleQuote(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`<input ref:"myInput"/>`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-string-refs", interceptor.Diagnostics[0].Name)
-}
-
-func TestStringRefsSingleQuote(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`<input ref:'myInput'/>`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-string-refs", interceptor.Diagnostics[0].Name)
-}
-
-func TestStringRefsNearMiss(t *testing.T) {
-	// ref: without quotes around the value should not trigger
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`ref:someVariable`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 0)
-}
-
-func TestCreateFactory(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`var el=React.createFactory(MyComponent)`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-create-factory", interceptor.Diagnostics[0].Name)
-}
-
-func TestFindDOMNode(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`var node=ReactDOM.findDOMNode(this)`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-find-dom-node", interceptor.Diagnostics[0].Name)
-}
-
-func TestReactDOMRender(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`ReactDOM.render(<App/>,document.getElementById("root"))`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-legacy-render", interceptor.Diagnostics[0].Name)
-}
-
-func TestUnmountComponentAtNode(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`ReactDOM.unmountComponentAtNode(container)`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-legacy-render", interceptor.Diagnostics[0].Name)
-}
-
-func TestLegacyRenderNearMiss(t *testing.T) {
-	// .render( without the ReactDOM. prefix should not trigger the legacy-render rule
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`component.render(props)`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 0)
-}
-
-func TestSecretInternals(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-secret-internals", interceptor.Diagnostics[0].Name)
-}
-
-func TestMultipleIssues(t *testing.T) {
-	// A bundle that hits several distinct rules should produce one diagnostic per rule.
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(
-			`MyComponent.propTypes={name:PropTypes.string}` +
-				`ReactDOM.render(<App/>,document.getElementById("root"))` +
-				`var node=ReactDOM.findDOMNode(this)`,
-		),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 3)
-
-	names := make([]string, 0, 3)
-	for _, d := range interceptor.Diagnostics {
-		names = append(names, d.Name)
-	}
-	require.Contains(t, names, "react-19-prop-types")
-	require.Contains(t, names, "react-19-legacy-render")
-	require.Contains(t, names, "react-19-find-dom-node")
-}
-
-func TestDetailContainsUpgradeGuideLink(t *testing.T) {
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.propTypes={}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Contains(t, interceptor.Diagnostics[0].Detail, react19UpgradeGuide)
-}
-
-func TestEachRuleReportedOnceEvenWithMultipleMatches(t *testing.T) {
-	// Both .propTypes= and .defaultProps= match the same rule; only one diagnostic should be emitted.
-	var interceptor testpassinterceptor.TestPassInterceptor
-	pass := newPass(&interceptor, map[string][]byte{
-		"module.js": []byte(`MyComponent.propTypes={} MyComponent.defaultProps={}`),
-	})
-
-	_, err := Analyzer.Run(pass)
-	require.NoError(t, err)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
 }

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -1,7 +1,6 @@
 package reactcompat
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -164,26 +163,6 @@ func TestReportIssuesNil(t *testing.T) {
 	count := reportIssues(pass, nil)
 	require.Equal(t, 0, count)
 	require.Len(t, interceptor.Diagnostics, 0)
-}
-
-// TestPrepareTmpDir verifies that prepareTmpDir creates the expected symlink
-// and that the cleanup function removes the directory.
-func TestPrepareTmpDir(t *testing.T) {
-	archiveDir := t.TempDir()
-
-	tmpDir, cleanup, err := prepareTmpDir(archiveDir)
-	require.NoError(t, err)
-	require.NotEmpty(t, tmpDir)
-
-	distLink := filepath.Join(tmpDir, "dist")
-	target, err := os.Readlink(distLink)
-	require.NoError(t, err)
-	require.Equal(t, archiveDir, target)
-
-	cleanup()
-
-	_, statErr := os.Stat(tmpDir)
-	require.True(t, os.IsNotExist(statErr), "temp dir should be removed after cleanup")
 }
 
 // TestNpxNotAvailable verifies that the analyzer silently skips (nil, nil) when

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -116,7 +116,7 @@ func TestReportIssuesSourceCode(t *testing.T) {
 	d := interceptor.Diagnostics[0]
 	require.Equal(t, "react-19-usePropTypes", d.Name)
 	require.Equal(t, analysis.Warning, d.Severity)
-	require.Equal(t, "Uses deprecated propTypes", d.Title)
+	require.Equal(t, "React 19 compatibility: Uses deprecated propTypes", d.Title)
 	require.Contains(t, d.Detail, "module.js")
 	require.Contains(t, d.Detail, "10")
 	require.Contains(t, d.Detail, "Remove propTypes.")
@@ -149,7 +149,7 @@ func TestReportIssuesDependency(t *testing.T) {
 	d := interceptor.Diagnostics[0]
 	require.Equal(t, "react-19-dep-oldReactDom", d.Name)
 	require.Equal(t, analysis.Warning, d.Severity)
-	require.Equal(t, "Depends on old react-dom", d.Title)
+	require.Equal(t, "React 19 compatibility: Depends on old react-dom", d.Title)
 	require.Contains(t, d.Detail, "react-dom, react")
 	require.Contains(t, d.Detail, "https://example.com/fix")
 	require.Contains(t, d.Detail, "this may be a false positive")

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -122,6 +122,7 @@ func TestReportIssuesSourceCode(t *testing.T) {
 	require.Contains(t, d.Detail, "10")
 	require.Contains(t, d.Detail, "Remove propTypes.")
 	require.Contains(t, d.Detail, "https://react.dev/upgrade")
+	require.Contains(t, d.Detail, "this may be a false positive")
 }
 
 // TestReportIssuesDependency verifies correct diagnostic generation for
@@ -152,6 +153,7 @@ func TestReportIssuesDependency(t *testing.T) {
 	require.Equal(t, "Depends on old react-dom", d.Title)
 	require.Contains(t, d.Detail, "react-dom, react")
 	require.Contains(t, d.Detail, "https://example.com/fix")
+	require.Contains(t, d.Detail, "this may be a false positive")
 }
 
 // TestReportIssuesNil verifies that a nil output produces no diagnostics.

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -164,8 +164,8 @@ func TestReportIssuesNil(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 0)
 }
 
-// TestNpxNotAvailable verifies that the analyzer reports a warning when
-// npx is not found in PATH.
+// TestNpxNotAvailable verifies that the analyzer silently skips when
+// npx is not found in PATH, producing no diagnostics.
 func TestNpxNotAvailable(t *testing.T) {
 	t.Setenv("PATH", "/nonexistent")
 
@@ -176,9 +176,7 @@ func TestNpxNotAvailable(t *testing.T) {
 	result, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Nil(t, result)
-	require.Len(t, interceptor.Diagnostics, 1)
-	require.Equal(t, "react-19-issue", interceptor.Diagnostics[0].Name)
-	require.Contains(t, interceptor.Diagnostics[0].Title, "npx not found")
+	require.Len(t, interceptor.Diagnostics, 0)
 }
 
 // TestReportIssuesCombined verifies that multiple source code issue groups and a

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -164,8 +164,8 @@ func TestReportIssuesNil(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 0)
 }
 
-// TestNpxNotAvailable verifies that the analyzer silently skips (nil, nil) when
-// npx is not found in PATH, producing no diagnostics.
+// TestNpxNotAvailable verifies that the analyzer reports a warning when
+// npx is not found in PATH.
 func TestNpxNotAvailable(t *testing.T) {
 	t.Setenv("PATH", "/nonexistent")
 
@@ -176,7 +176,9 @@ func TestNpxNotAvailable(t *testing.T) {
 	result, err := Analyzer.Run(pass)
 	require.NoError(t, err)
 	require.Nil(t, result)
-	require.Len(t, interceptor.Diagnostics, 0)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-issue", interceptor.Diagnostics[0].Name)
+	require.Contains(t, interceptor.Diagnostics[0].Title, "npx not found")
 }
 
 // TestReportIssuesCombined verifies that multiple source code issue groups and a

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -1,7 +1,6 @@
 package reactcompat
 
 import (
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -168,9 +167,7 @@ func TestReportIssuesNil(t *testing.T) {
 // TestNpxNotAvailable verifies that the analyzer silently skips (nil, nil) when
 // npx is not found in PATH, producing no diagnostics.
 func TestNpxNotAvailable(t *testing.T) {
-	if _, err := exec.LookPath("npx"); err == nil {
-		t.Skip("npx is available in this environment; skipping npx-not-found test")
-	}
+	t.Setenv("PATH", "/nonexistent")
 
 	archiveDir := t.TempDir()
 	var interceptor testpassinterceptor.TestPassInterceptor

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -1,0 +1,267 @@
+package reactcompat
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/plugin-validator/pkg/analysis"
+	"github.com/grafana/plugin-validator/pkg/analysis/passes/modulejs"
+	"github.com/grafana/plugin-validator/pkg/testpassinterceptor"
+)
+
+func newPass(interceptor *testpassinterceptor.TestPassInterceptor, content map[string][]byte) *analysis.Pass {
+	return &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			modulejs.Analyzer: content,
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+}
+
+func TestCleanPlugin(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`import { PanelPlugin } from '@grafana/data'`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	// No warnings; the OK rule only fires when ReportAll is set.
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestNoModuleJs(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := &analysis.Pass{
+		RootDir: filepath.Join("./"),
+		ResultOf: map[*analysis.Analyzer]interface{}{
+			modulejs.Analyzer: map[string][]byte{},
+		},
+		Report: interceptor.ReportInterceptor(),
+	}
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestPropTypes(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.propTypes={name:PropTypes.string}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
+	require.Equal(t, analysis.Warning, interceptor.Diagnostics[0].Severity)
+}
+
+func TestDefaultProps(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.defaultProps={name:"default"}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
+}
+
+func TestContextTypes(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.contextTypes={theme:PropTypes.object}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
+}
+
+func TestChildContextTypes(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.childContextTypes={theme:PropTypes.object}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
+}
+
+func TestGetChildContext(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`getChildContext(){return{theme:this.state.theme}}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-legacy-context", interceptor.Diagnostics[0].Name)
+}
+
+func TestStringRefsDoubleQuote(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`<input ref:"myInput"/>`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-string-refs", interceptor.Diagnostics[0].Name)
+}
+
+func TestStringRefsSingleQuote(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`<input ref:'myInput'/>`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-string-refs", interceptor.Diagnostics[0].Name)
+}
+
+func TestStringRefsNearMiss(t *testing.T) {
+	// ref: without quotes around the value should not trigger
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`ref:someVariable`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestCreateFactory(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`var el=React.createFactory(MyComponent)`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-create-factory", interceptor.Diagnostics[0].Name)
+}
+
+func TestFindDOMNode(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`var node=ReactDOM.findDOMNode(this)`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-find-dom-node", interceptor.Diagnostics[0].Name)
+}
+
+func TestReactDOMRender(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`ReactDOM.render(<App/>,document.getElementById("root"))`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-legacy-render", interceptor.Diagnostics[0].Name)
+}
+
+func TestUnmountComponentAtNode(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`ReactDOM.unmountComponentAtNode(container)`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-legacy-render", interceptor.Diagnostics[0].Name)
+}
+
+func TestLegacyRenderNearMiss(t *testing.T) {
+	// .render( without the ReactDOM. prefix should not trigger the legacy-render rule
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`component.render(props)`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestSecretInternals(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-secret-internals", interceptor.Diagnostics[0].Name)
+}
+
+func TestMultipleIssues(t *testing.T) {
+	// A bundle that hits several distinct rules should produce one diagnostic per rule.
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(
+			`MyComponent.propTypes={name:PropTypes.string}` +
+				`ReactDOM.render(<App/>,document.getElementById("root"))` +
+				`var node=ReactDOM.findDOMNode(this)`,
+		),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 3)
+
+	names := make([]string, 0, 3)
+	for _, d := range interceptor.Diagnostics {
+		names = append(names, d.Name)
+	}
+	require.Contains(t, names, "react-19-prop-types")
+	require.Contains(t, names, "react-19-legacy-render")
+	require.Contains(t, names, "react-19-find-dom-node")
+}
+
+func TestDetailContainsUpgradeGuideLink(t *testing.T) {
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.propTypes={}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Contains(t, interceptor.Diagnostics[0].Detail, react19UpgradeGuide)
+}
+
+func TestEachRuleReportedOnceEvenWithMultipleMatches(t *testing.T) {
+	// Both .propTypes= and .defaultProps= match the same rule; only one diagnostic should be emitted.
+	var interceptor testpassinterceptor.TestPassInterceptor
+	pass := newPass(&interceptor, map[string][]byte{
+		"module.js": []byte(`MyComponent.propTypes={} MyComponent.defaultProps={}`),
+	})
+
+	_, err := Analyzer.Run(pass)
+	require.NoError(t, err)
+	require.Len(t, interceptor.Diagnostics, 1)
+	require.Equal(t, "react-19-prop-types", interceptor.Diagnostics[0].Name)
+}

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -159,14 +159,6 @@ func TestIntegration(t *testing.T) {
 							Name:     "sponsorshiplink",
 						},
 					},
-					"provenance": {
-						{
-							Severity: "recommendation",
-							Title:    "No provenance attestation. This plugin was built without build verification",
-							Detail:   "Cannot verify plugin build. It is recommended to use a pipeline that supports provenance attestation, such as GitHub Actions. https://github.com/grafana/plugin-actions/tree/main/build-plugin",
-							Name:     "no-provenance-attestation",
-						},
-					},
 				},
 			},
 		},

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -159,6 +159,14 @@ func TestIntegration(t *testing.T) {
 							Name:     "sponsorshiplink",
 						},
 					},
+					"provenance": {
+						{
+							Severity: "recommendation",
+							Title:    "No provenance attestation. This plugin was built without build verification",
+							Detail:   "Cannot verify plugin build. It is recommended to use a pipeline that supports provenance attestation, such as GitHub Actions. https://github.com/grafana/plugin-actions/tree/main/build-plugin",
+							Name:     "no-provenance-attestation",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### What changed?

Adds a `reactcompat` analyzer that delegates React 19 compatibility detection to `@grafana/react-detect` via `npx`.

**Why a separate analyzer instead of semgrep rules?** We already have a tool for detecting the react-19 compatibility for plugins: [@grafana/react-detect](https://github.com/grafana/plugin-tools/tree/main/packages/react-detect), it makes sense to have a single source of truth for the logic.

**How it works:**
- Runs `npx -y @grafana/react-detect@latest --json --distDir <archive>` against the extracted plugin zip
- Parses the JSON output and maps each issue to a warning-level diagnostic prefixed with "React 19 compatibility:"
- Silently skips if `npx` is not available (graceful degradation)
- Includes a false-positive disclaimer since sourcemap-based detection can be imprecise
- All diagnostics are warnings, not errors — the check is advisory

**How I tested:**
Locally with both a react-19 incompatible and compatible plugin bundle, e.g.
```bash
./plugincheck2 -config config/default.yaml /tmp/leventebalogh-react19incompatible-app.zip
```