### PR TITLE
chore(ci): migrate to docker-build-push-image action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,10 @@ jobs:
           echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
 
       - id: push-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@f02d5da7ddff4ea32bbe5034c7c70e90d2b9622c # build-push-to-dockerhub/v0.4.1
+        uses: grafana/shared-workflows/actions/docker-build-push-image@21ae57f82e5256e5a418406388926d4ba24bccf2 # docker-build-push-image/v0.3.2
         with:
-          repository: grafana/plugin-validator-cli
+          dockerhub-repository: grafana/plugin-validator-cli
+          registries: dockerhub
           context: .
           tags: |-
             "v${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
Migrates from the deprecated `build-push-to-dockerhub` action to the unified [`docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) action.

## What This Changes

- Updated action reference from `build-push-to-dockerhub` to `docker-build-push-image@v0.3.2`
- Renamed `repository` input to `dockerhub-repository`
- Added `registries: dockerhub` input

## References

- [docker-build-push-image docs](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image)
- [Migration guide](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating-from-push-to-gar-docker)
- [Repo migration tracking issue](https://github.com/grafana/deployment_tools/issues/390404)