### PR TITLE
Release docs: Improve release documentation

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,18 +1,49 @@
 # How to release a new version
 
-**IMPORTANT:** Do not push release tags manually
+**IMPORTANT:** Do not push release tags manually. The entire release process is automated via GitHub Actions.
 
-* Go to Actions -> Bump version
-* Click on "Run workflow"
-* Keep branch: main
-* Select the type of new version (patch, minor, major)
-* Run workflow
+## Plugin Validator
 
->External contributors note: For security purposes, externals contributors don't usually have permissions to create new releases.
+Use the ["Bump Version and release"](https://github.com/grafana/plugin-validator/actions/workflows/do-release.yml) workflow:
 
-This will trigger a series of github actions to build a new github release and automatically push to npm
+1. Click **"Run workflow"**
+2. Keep branch: `main`
+3. Select the semver type: `patch`, `minor`, or `major`
+4. Click **"Run workflow"**
 
+### Which semver type to choose?
 
-# Github or NPM tokens expiration
+- **patch** -- bug fixes, dependency updates, documentation changes
+- **minor** -- new features (e.g. adding a new validator)
+- **major** -- breaking changes to the CLI interface, output format, or public API
 
-Github and NPM tokens are required to auto-publish. These tokens eventually expire. If there's an error pushing tags to github or updates to npm make sure to review the tokens expiration.
+### What happens after the workflow runs?
+
+The workflow bumps the version in `package.json`, commits to `main`, and pushes a `v*` tag. The tag push automatically triggers the ["Create release and publish"](https://github.com/grafana/plugin-validator/actions/workflows/release.yml) workflow, which:
+
+1. Builds binaries via GoReleaser (Linux, Windows, Darwin) and creates a **GitHub Release**
+2. Publishes to **npm** (`@grafana/plugin-validator`)
+3. Pushes a **Docker image** to `grafana/plugin-validator-cli` (tagged with the version and `latest`)
+
+## MCP Server
+
+The MCP server has its own, independent release track. Use the ["Release MCP Server"](https://github.com/grafana/plugin-validator/actions/workflows/do-release-mcp.yml) workflow:
+
+1. Click **"Run workflow"**
+2. Keep branch: `main`
+3. Select the semver type: `patch`, `minor`, or `major`
+4. Click **"Run workflow"**
+
+This bumps the version in `mcp-package/package.json`, commits to `main`, and pushes a `mcp/v*` tag. The tag push automatically triggers the ["Create MCP release and publish"](https://github.com/grafana/plugin-validator/actions/workflows/release-mcp.yml) workflow, which:
+
+1. Builds binaries via GoReleaser (Linux, Windows, Darwin -- both amd64 and arm64) and creates a **GitHub Release**
+2. Publishes to **npm** (`@grafana/plugin-validator-mcp`)
+
+## Permissions
+
+> [!NOTE]
+> For security purposes, external contributors don't usually have permissions to create new releases.
+
+## GitHub or NPM tokens expiration
+
+GitHub and NPM tokens are required to auto-publish. These tokens eventually expire. If there's an error pushing tags to GitHub or updates to npm, review the token expiration. See the [secrets usage table](https://grafana.github.io/grafana-catalog-team/secrets-rotation/secrets-usage-table/) for details on which secrets are used and who owns them.


### PR DESCRIPTION
### What changed?

Updated the release guidance a bit to contain more information about the release process, and also to link to the actual workflows that are used for kicking off a new release. 

[Preview &rarr;](https://github.com/grafana/plugin-validator/blob/leventebalogh/release-docs/HOW_TO_RELEASE.md)