### PR TITLE
chore: add docsPath to plugin.json schema

### DIFF
--- a/config/plugin.schema.json
+++ b/config/plugin.schema.json
@@ -249,6 +249,10 @@
       "type": "string",
       "description": "Plugin category used on the Add new connection page. Can be one from the list: \"tsdb\", \"logging\", \"cloud\", \"tracing\", \"profiling\", \"sql\", \"enterprise\", \"iot\", \"other\", empty string or custom string"
     },
+    "docsPath": {
+      "type": "string",
+      "description": "Path to the directory containing plugin documentation."
+    },
     "enterpriseFeatures": {
       "type": "object",
       "description": "Grafana Enterprise specific features",


### PR DESCRIPTION
Adds `docsPath` as an allowed property in the plugin.json JSON schema.

The field is already implemented in the validator's Go struct and analysis pass but was missing from the schema, which would cause schema-based validation to reject it as an unknown property.