### PR TITLE
chore(deps): bump github.com/docker/docker to v28.5.2 [security]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/djherbis/times v1.6.0 // indirect
 	github.com/docker/cli v29.2.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v28.3.3+incompatible // indirect
+	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-events v0.0.0-20250114142523-c867878c5e32 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/docker/cli v29.2.0+incompatible h1:9oBd9+YM7rxjZLfyMGxjraKBKE4/nVyvVf
 github.com/docker/cli v29.2.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
-github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
+github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=


### PR DESCRIPTION
## Summary

- Bumps transitive dep `github.com/docker/docker` from v28.3.3 → v28.5.2 (latest available on the legacy module path).
- Narrows exposure for [GHSA-x744-4wpc-v9h2 / CVE-2026-34040](https://github.com/grafana/plugin-validator/security/dependabot/52) — Moby AuthZ plugin bypass via oversized request bodies.

## Notes on the alert

The advisory's first patched version (v29.3.1 / `moby/moby/v2 >= 2.0.0-beta.8`) lives on a **new module path** that none of our transitive deps consume yet. v28.5.2 is the highest version available on `github.com/docker/docker` today, so this PR alone will not clear Dependabot alert #52.

The vulnerable code path is **not in this binary's execution surface**:
- `plugin-validator` does not import `docker/docker` directly (verified via grep).
- Only `docker/docker/api/types/*` (struct definitions) are linked via `osv-scanner` → `osv-scalibr` → `go-containerregistry`.
- The vulnerability is in the Docker daemon's authorization-plugin request handler. `plugin-validator` is a CLI; it never runs a Docker daemon.

After merge, the alert will be dismissed as "vulnerable code is not in execution path."

## Test plan

- [x] `go build ./...` clean
- [x] `go mod tidy` no-op after bump
- [x] `go test ./...` — all packages pass except a pre-existing `pkg/runner` failure on `main` (local env missing `react-detect`, unrelated to this change)