### PR TITLE
ci: release via PR instead of direct push to main

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
 
     steps:
       - id: get-secrets
@@ -35,6 +36,7 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -46,14 +48,35 @@ jobs:
           git config user.name 'grafana-plugins-platform-bot[bot]'
           git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
 
-      - name: bump version
-        run: npm version ${INPUT_VERSION}
+      - name: Bump version
+        id: bump
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          NEW_VERSION=$(npm version "$INPUT_VERSION" --no-git-tag-version)
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/bump-$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Push latest version
-        run: git push origin main
+      - name: Commit and push branch
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+        run: |
+          git switch -c "$BRANCH"
+          git add package.json package-lock.json
+          git commit -m "chore: release $NEW_VERSION"
+          git push origin "$BRANCH"
 
-      - name: Push tags
-        run: git push origin --tags
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+          BRANCH: ${{ steps.bump.outputs.branch }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: release $NEW_VERSION" \
+            --body "Automated version bump to \`$NEW_VERSION\`.
+
+          Once this PR is merged, the **Tag on version bump** workflow will create the \`$NEW_VERSION\` tag, which triggers the release pipeline (GitHub Release, npm, Docker)."

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -1,0 +1,64 @@
+name: Tag on version bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+
+jobs:
+  tag:
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # v1.3.0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app_id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
+          export_env: false
+
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true
+
+      - name: Setup Git
+        run: |
+          git config user.name 'grafana-plugins-platform-bot[bot]'
+          git config user.email '144369747+grafana-plugins-platform-bot[bot]@users.noreply.github.com'
+
+      - name: Tag if version changed
+        run: |
+          NEW_VERSION=$(jq -r .version package.json)
+          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            PREV_VERSION=$(git show HEAD~1:package.json 2>/dev/null | jq -r .version)
+          else
+            PREV_VERSION=""
+          fi
+          if [ "$NEW_VERSION" = "$PREV_VERSION" ]; then
+            echo "Version unchanged ($NEW_VERSION). Nothing to do."
+            exit 0
+          fi
+          TAG="v$NEW_VERSION"
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+            exit 0
+          fi
+          echo "Creating and pushing tag $TAG"
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -19,7 +19,9 @@ Use the ["Bump Version and release"](https://github.com/grafana/plugin-validator
 
 ### What happens after the workflow runs?
 
-The workflow bumps the version in `package.json`, commits to `main`, and pushes a `v*` tag. The tag push automatically triggers the ["Create release and publish"](https://github.com/grafana/plugin-validator/actions/workflows/release.yml) workflow, which:
+The workflow bumps the version in `package.json` on a new branch and opens a pull request titled `chore: release vX.Y.Z`. **Review and squash-merge the PR** to continue the release.
+
+When the PR merges, the ["Tag on version bump"](https://github.com/grafana/plugin-validator/actions/workflows/tag-on-version-bump.yml) workflow detects the version change and pushes a `v*` tag. The tag push automatically triggers the ["Create release and publish"](https://github.com/grafana/plugin-validator/actions/workflows/release.yml) workflow, which:
 
 1. Builds binaries via GoReleaser (Linux, Windows, Darwin) and creates a **GitHub Release**
 2. Publishes to **npm** (`@grafana/plugin-validator`)


### PR DESCRIPTION
## Summary

The org-level **"Public repo required PRs"** ruleset (id `15595097`) blocks direct pushes to `main`, which broke the existing release flow — see failed run https://github.com/grafana/plugin-validator/actions/runs/25546676728.

This PR splits the release into two stages so it works under the new policy:

- **`do-release.yml`** (workflow_dispatch, unchanged trigger): bumps the version on a `release/bump-vX.Y.Z` branch and opens a PR. No tag, no main push.
- **`tag-on-version-bump.yml`** (new, triggers on `push` to `main` with `package.json` change): if `package.json`'s version differs from the previous commit and the corresponding `vX.Y.Z` tag doesn't already exist, create and push the tag. The tag push triggers the existing `release.yml`, which publishes the GitHub Release, the npm package, and the Docker image.

Tag pushes aren't blocked by the org ruleset (it targets `branch` refs only), so step 2 works under the existing rules.

`HOW_TO_RELEASE.md` is updated to reflect the new step (review and squash-merge the auto-PR).

## Notes

- `do-release-mcp.yml` has the same problem and will need an analogous fix. Out of scope for this PR.
- This change does **not** modify any rulesets.

## Test plan

- [ ] Merge this PR.
- [ ] Dispatch the **Bump Version and release** workflow with `version=patch`.
- [ ] Verify a `release/bump-v0.41.1` branch and matching PR are created automatically.
- [ ] Squash-merge that PR.
- [ ] Verify **Tag on version bump** runs and pushes `v0.41.1`.
- [ ] Verify **Create release and publish** triggers and publishes the GitHub Release, npm, and Docker image.