### PR TITLE
fix(ci): handle release-please prefixed tags in goreleaser publish

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -41,20 +41,17 @@ jobs:
       - name: Extract MCP version
         run: echo "MCP_VERSION=${GITHUB_REF_NAME#mcp/v}" >> $GITHUB_ENV
 
-      - name: Find previous MCP tag
-        run: |
-          PREV=$(git tag --sort=-version:refname | grep '^mcp/v' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
-          echo "MCP_PREVIOUS_TAG=${PREV}" >> $GITHUB_ENV
-
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --config .goreleaser.mcp.yaml --skip=validate
+          args: release --clean --config .goreleaser.mcp.yaml
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
-          GORELEASER_PREVIOUS_TAG: ${{ env.MCP_PREVIOUS_TAG }}
+          # Override the parsed tag with the bare semver so GoReleaser's
+          # validation passes; the actual GitHub release tag is set via
+          # `release.tag` in .goreleaser.mcp.yaml.
+          GORELEASER_CURRENT_TAG: v${{ env.MCP_VERSION }}
           MCP_VERSION: ${{ env.MCP_VERSION }}
 
   release-mcp-to-npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,21 +42,18 @@ jobs:
       - name: Extract release version
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#plugin-validator/v}" >> "$GITHUB_ENV"
 
-      - name: Find previous tag
-        run: |
-          PREV=$(git tag --sort=-version:refname | grep '^plugin-validator/v' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
-          echo "PREVIOUS_TAG=${PREV}" >> "$GITHUB_ENV"
-
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip=validate
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
-          GORELEASER_PREVIOUS_TAG: ${{ env.PREVIOUS_TAG }}
+          # Override the parsed tag with the bare semver so GoReleaser's
+          # validation passes; the actual GitHub release tag is set via
+          # `release.tag` in .goreleaser.yaml.
+          GORELEASER_CURRENT_TAG: v${{ env.RELEASE_VERSION }}
 
   release-to-npm:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,21 @@ jobs:
       - name: Extract release version
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#plugin-validator/v}" >> "$GITHUB_ENV"
 
+      - name: Find previous tag
+        run: |
+          PREV=$(git tag --sort=-version:refname | grep '^plugin-validator/v' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          echo "PREVIOUS_TAG=${PREV}" >> "$GITHUB_ENV"
+
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GORELEASER_PREVIOUS_TAG: ${{ env.PREVIOUS_TAG }}
 
   release-to-npm:
     runs-on: ubuntu-latest

--- a/.goreleaser.mcp.yaml
+++ b/.goreleaser.mcp.yaml
@@ -38,3 +38,4 @@ changelog:
 
 release:
   mode: keep-existing
+  tag: "mcp/v{{ .Version }}"

--- a/.goreleaser.mcp.yaml
+++ b/.goreleaser.mcp.yaml
@@ -35,3 +35,6 @@ checksum:
 
 changelog:
   disable: true
+
+release:
+  mode: keep-existing

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,6 +37,7 @@ changelog:
       - "^test:"
 release:
   mode: keep-existing
+  tag: "plugin-validator/v{{ .Version }}"
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,8 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  mode: keep-existing
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
## Summary
- Pass the **bare** semver (e.g. `v0.42.0`) via `GORELEASER_CURRENT_TAG` so GoReleaser's semver parser succeeds.
- Set `release.tag` in both goreleaser configs (`plugin-validator/v{{ .Version }}` and `mcp/v{{ .Version }}`) so the GitHub release is still associated with the full prefixed tag created by release-please.
- Set `release.mode: keep-existing` so GoReleaser appends archives + checksums to the release-please-created GitHub release without overwriting its notes.
- Apply the same pattern to `release-mcp.yml` / `.goreleaser.mcp.yaml` so the first MCP release-please release won't hit the same trap.

## Why
The first release after the release-please migration ([plugin-validator/v0.42.0](https://github.com/grafana/plugin-validator/releases/tag/plugin-validator%2Fv0.42.0)) shipped with **zero assets**. The publish workflow [run 25553633790](https://github.com/grafana/plugin-validator/actions/runs/25553633790) failed at the GoReleaser step:

```
release failed after 0s
error=failed to parse tag 'plugin-validator/v0.42.0' as semver: invalid semantic version
```

release-please uses `tag-separator: "/"` (monorepo mode for plugin-validator + mcp-package), so tags now look like `plugin-validator/v0.42.0`. GoReleaser inspects the git tag and fails its semver check before producing any artifacts.

## Why not `--skip=validate`?
A first pass on this used `--skip=validate`. That works but disables the entire validate pipe (git-state checks, template validation, file-collision checks, etc.), not just the semver parse. Decoupling the parsed version from the release tag via `release.tag` keeps validation on while still solving the actual problem.

The GoReleaser-Pro `monorepo` block would be the most idiomatic fix but requires a Pro license.

## Test plan
- [ ] After merge, force-update `plugin-validator/v0.42.0` to the merge commit and re-push to retrigger the publish workflow
- [ ] Confirm the publish workflow succeeds and uploads 8 archives + `checksums.txt` to the v0.42.0 release
- [ ] Verify release-please's release notes on v0.42.0 are unchanged
- [ ] Verify Docker Hub push and npm publish complete (downstream of `release-to-github`)