### PR TITLE
fix(ci): skip goreleaser validate pipe for prefixed tags

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -45,13 +45,14 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --config .goreleaser.mcp.yaml
+          # release-please tags look like `mcp/v0.1.2`, which GoReleaser's
+          # validate pipe can't parse as semver. Skip it; the archive name
+          # template uses `MCP_VERSION` directly and `release.mode:
+          # keep-existing` preserves release-please's notes.
+          args: release --clean --config .goreleaser.mcp.yaml --skip=validate
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          # Override the parsed tag with the bare semver so GoReleaser's
-          # validation passes; the actual GitHub release tag is set via
-          # `release.tag` in .goreleaser.mcp.yaml.
-          GORELEASER_CURRENT_TAG: v${{ env.MCP_VERSION }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           MCP_VERSION: ${{ env.MCP_VERSION }}
 
   release-mcp-to-npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,15 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          # release-please tags look like `plugin-validator/v0.42.0`, which
+          # GoReleaser's validate pipe can't parse as semver. Skip it; the
+          # archive name template uses `RELEASE_VERSION` directly and
+          # `release.mode: keep-existing` preserves release-please's notes.
+          args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          # Override the parsed tag with the bare semver so GoReleaser's
-          # validation passes; the actual GitHub release tag is set via
-          # `release.tag` in .goreleaser.yaml.
-          GORELEASER_CURRENT_TAG: v${{ env.RELEASE_VERSION }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   release-to-npm:
     runs-on: ubuntu-latest

--- a/.goreleaser.mcp.yaml
+++ b/.goreleaser.mcp.yaml
@@ -38,4 +38,3 @@ changelog:
 
 release:
   mode: keep-existing
-  tag: "mcp/v{{ .Version }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,6 @@ changelog:
       - "^test:"
 release:
   mode: keep-existing
-  tag: "plugin-validator/v{{ .Version }}"
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json


### PR DESCRIPTION
## Summary
Replaces the `release.tag` config knob (which only exists in GoReleaser **Pro**) with `--skip=validate`, the same pattern the MCP workflow already uses. Also keeps `GORELEASER_CURRENT_TAG: \${{ github.ref_name }}` so the GitHub release goes to the right (prefixed) tag.

## Why
PR #575 tried to keep validation on by setting `release.tag: "plugin-validator/v{{ .Version }}"` in the goreleaser configs. That field isn't in the OSS schema, so v2.15.4 rejects it:

\`\`\`
yaml: unmarshal errors:
  line 40: field tag not found in type config.Release
\`\`\`

[Failed run after #575 merged](https://github.com/grafana/plugin-validator/actions/runs/25554935900)

`--skip=validate` skips the validate pipe (semver parse, working-tree check, template validation) but in a post-tag-push CI run those checks aren't really protecting us — fresh checkout, known-good tag.

## Test plan
- [ ] After merge, force-update \`plugin-validator/v0.42.0\` to the merge commit and re-push to retrigger the publish workflow
- [ ] Confirm publish succeeds and uploads 8 archives + \`checksums.txt\` to the v0.42.0 release
- [ ] Verify release-please's release notes on v0.42.0 are unchanged
- [ ] Verify Docker Hub push and npm publish complete (downstream of \`release-to-github\`)