### PR TITLE
disable npm/pnpm/yarn lifecycle scripts

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/mcp-package/.npmrc
+++ b/mcp-package/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
npm and pnpm were already covered by the existing .npmrc. This adds the equivalent for yarn v1 (.yarnrc) and yarn berry (.yarnrc.yml), and carries the same config into mcp-package.