### PR TITLE
fix: code-rules per-rule exceptions and severity config not applied

### DIFF
--- a/pkg/analysis/passes/coderules/coderules.go
+++ b/pkg/analysis/passes/coderules/coderules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/plugin-validator/pkg/analysis"
 	"github.com/grafana/plugin-validator/pkg/analysis/passes/sourcecode"
 	"github.com/grafana/plugin-validator/pkg/logme"
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed semgrep-rules.yaml
@@ -32,6 +33,11 @@ var (
 	}
 )
 
+// semgrepRulesMap is populated at init() time by parsing the embedded semgrep-rules.yaml.
+// It maps rule name (e.g. "code-rules-no-direct-css-imports") to its pre-registered *analysis.Rule
+// so that initAnalyzers() can apply config overrides (severity, disabled, exceptions) before run().
+var semgrepRulesMap = map[string]*analysis.Rule{}
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "code-rules",
 	Requires: []*analysis.Analyzer{sourcecode.Analyzer},
@@ -46,6 +52,35 @@ var Analyzer = &analysis.Analyzer{
 		Description:  "Checks for forbidden access to environment variables, file system or use of syscall module.",
 		Dependencies: "[semgrep](https://github.com/returntocorp/semgrep), `sourceCodeUri`",
 	},
+}
+
+type semgrepRuleEntry struct {
+	ID       string `yaml:"id"`
+	Severity string `yaml:"severity"`
+}
+
+type semgrepRulesFile struct {
+	Rules []semgrepRuleEntry `yaml:"rules"`
+}
+
+func init() {
+	var rulesFile semgrepRulesFile
+	if err := yaml.Unmarshal([]byte(semgrepRules), &rulesFile); err != nil {
+		panic(fmt.Sprintf("coderules: failed to parse embedded semgrep-rules.yaml: %v", err))
+	}
+	for _, entry := range rulesFile.Rules {
+		var severity analysis.Severity
+		switch strings.ToLower(entry.Severity) {
+		case "error":
+			severity = analysis.Error
+		default:
+			severity = analysis.Warning
+		}
+		ruleName := fmt.Sprintf("code-rules-%s", entry.ID)
+		rule := &analysis.Rule{Name: ruleName, Severity: severity}
+		semgrepRulesMap[ruleName] = rule
+		Analyzer.Rules = append(Analyzer.Rules, rule)
+	}
 }
 
 func run(pass *analysis.Pass) (any, error) {
@@ -110,7 +145,8 @@ func run(pass *analysis.Pass) (any, error) {
 	for _, result := range semgrepResults.Results {
 		var rule *analysis.Rule
 
-		// Use CheckID to create specific rule, fallback to generic rules if missing
+		// Use CheckID to look up the pre-registered rule so that config overrides
+		// (severity, disabled, exceptions) applied by initAnalyzers() are respected.
 		if result.CheckID != "" {
 			// Strip any namespace prefix from CheckID (e.g., "tmp.detect-console-logs" -> "detect-console-logs")
 			// The prefix comes from semgrep's internal namespacing based on the rules file path/name
@@ -119,19 +155,19 @@ func run(pass *analysis.Pass) (any, error) {
 				checkID = checkID[idx+1:]
 			}
 			ruleName := fmt.Sprintf("code-rules-%s", checkID)
-			severity := strings.ToLower(result.Extra.Severity)
-			var ruleSeverity analysis.Severity
-			switch severity {
-			case "error":
-				ruleSeverity = analysis.Error
-			case "warning":
-				ruleSeverity = analysis.Warning
-			default:
-				ruleSeverity = analysis.Warning
-			}
-			rule = &analysis.Rule{
-				Name:     ruleName,
-				Severity: ruleSeverity,
+			if r, ok := semgrepRulesMap[ruleName]; ok {
+				rule = r
+			} else {
+				// Unknown rule not in semgrep-rules.yaml — fall back to a generic rule
+				severity := strings.ToLower(result.Extra.Severity)
+				var ruleSeverity analysis.Severity
+				switch severity {
+				case "error":
+					ruleSeverity = analysis.Error
+				default:
+					ruleSeverity = analysis.Warning
+				}
+				rule = &analysis.Rule{Name: ruleName, Severity: ruleSeverity}
 			}
 		} else {
 			// Fallback to generic rules if CheckID is missing

--- a/pkg/analysis/passes/coderules/coderules_test.go
+++ b/pkg/analysis/passes/coderules/coderules_test.go
@@ -617,6 +617,56 @@ func TestTsIgnoreSuppressGood(t *testing.T) {
 	require.Len(t, interceptor.Diagnostics, 0)
 }
 
+// TestRuleExceptionSuppressesDiagnostic verifies that run() uses the pre-registered
+// rule pointer from semgrepRulesMap, so that when initAnalyzers() marks a rule as
+// Disabled (e.g. due to a per-rule exception in the config), the diagnostic is suppressed.
+// The test first confirms the violation is reported normally, then disables the rule via
+// the pre-registered pointer (as initAnalyzers() would) and confirms it is gone.
+func TestRuleExceptionSuppressesDiagnostic(t *testing.T) {
+	if !isSemgrepInstalled() {
+		t.Skip("semgrep not installed, skipping test")
+		return
+	}
+
+	ruleName := "code-rules-no-direct-css-imports"
+	resultOf := map[*analysis.Analyzer]interface{}{
+		sourcecode.Analyzer: filepath.Join("testdata", "no-direct-css-imports"),
+	}
+
+	// First: confirm the violation is reported when the rule is enabled.
+	var withRule testpassinterceptor.TestPassInterceptor
+	_, err := Analyzer.Run(&analysis.Pass{
+		RootDir:  filepath.Join("./"),
+		ResultOf: resultOf,
+		Report:   withRule.ReportInterceptor(),
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(withRule.Diagnostics), 0, "expected violations before disabling rule")
+	ruleNames := make([]string, 0, len(withRule.Diagnostics))
+	for _, d := range withRule.Diagnostics {
+		ruleNames = append(ruleNames, d.Name)
+	}
+	require.Contains(t, ruleNames, ruleName, "expected %q diagnostic before disabling", ruleName)
+
+	// Now disable the rule via the pre-registered pointer, as initAnalyzers() does.
+	rule, ok := semgrepRulesMap[ruleName]
+	require.True(t, ok, "rule %q must be pre-registered in semgrepRulesMap", ruleName)
+	rule.Disabled = true
+	defer func() { rule.Disabled = false }()
+
+	// Confirm the diagnostic is now suppressed.
+	var withException testpassinterceptor.TestPassInterceptor
+	_, err = Analyzer.Run(&analysis.Pass{
+		RootDir:  filepath.Join("./"),
+		ResultOf: resultOf,
+		Report:   withException.ReportInterceptor(),
+	})
+	require.NoError(t, err)
+	for _, d := range withException.Diagnostics {
+		require.NotEqual(t, ruleName, d.Name, "disabled rule %q must not produce diagnostics", ruleName)
+	}
+}
+
 func TestNoDirectCSSImports(t *testing.T) {
 	if !isSemgrepInstalled() {
 		t.Skip("semgrep not installed, skipping test")


### PR DESCRIPTION
Rules like code-rules-no-direct-css-imports were allocated fresh inside run() on each semgrep result, so initAnalyzers() could never mark them disabled. Pre-registering all semgrep rules at init() time fixes this.