### PR TITLE
chore(deps): pin npm dependencies to exact lockfile versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 ignore-scripts=true
+allow-git=none
+min-release-age=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.42.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "tar": "^7.4.3"
+        "tar": "7.5.11"
       },
       "bin": {
         "plugin-validator": "bin/index.js"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "urlTemplate": "https://github.com/grafana/plugin-validator/releases/download/plugin-validator/v{{version}}/plugin-validator_{{version}}_{{platform}}_{{arch}}.tar.gz"
   },
   "dependencies": {
-    "tar": "^7.4.3"
+    "tar": "7.5.11"
   }
 }


### PR DESCRIPTION
## Summary

- Replace semver ranges in `dependencies` and `devDependencies` with the exact versions already resolved in `package-lock.json`. Direct deps will no longer drift across reinstalls.
- Harden `.npmrc` with supply-chain settings:
  - `allow-git=none` (block git dependencies)
  - `ignore-scripts=true` (idempotent if already present)
  - `min-release-age=3` (only install packages at least 3 days old)
- `peerDependencies` and `optionalDependencies` are intentionally left as ranges. Specifiers using `file:`, `link:`, `workspace:`, `git+`, `npm:` (alias), `http(s):`, or `*` / `latest` are also untouched.

Generated by a script that reads `package-lock.json` and rewrites the direct dep ranges in every `package.json` to the resolved version. `npm install` after the change is a no-op (no resolved versions changed).

## Test plan
- [ ] CI green
- [ ] `npm install` produces no further changes