### PR TITLE
ci: use GATB for release and release-mcp GitHub tokens

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -22,21 +22,11 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # v1.3.0
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app_id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
-          export_env: false
-
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
+          github_app: plugins-platform-bot-app
 
       - name: Extract MCP version
         run: echo "MCP_VERSION=${GITHUB_REF_NAME#mcp/v}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,21 +23,11 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # v1.3.0
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app_id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
-          export_env: false
-
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
+          github_app: plugins-platform-bot-app
 
       - name: Extract release version
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#plugin-validator/v}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Switches release.yml and release-mcp.yml from fetching bot credentials from Vault to grafana/shared-workflows/actions/create-github-app-token. Requires the GATB config in grafana/deployment_tools (link once merged).