### PR TITLE
reactcompat: run in CI and make output reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GOLANGCI_LINT_VERSION=v2.5.0
 ARG GOSEC_VERSION=v2.22.8
 ARG SEMGREP_VERSION=1.84.1
 
-FROM golang:1.25-alpine3.22@sha256:fa3380ab0d73b706e6b07d2a306a4dc68f20bfc1437a6a6c47c8f88fe4af6f75 AS builder
+FROM golang:1.25-alpine3.23@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 
 ARG GOLANGCI_LINT_VERSION
 ARG GOSEC_VERSION
@@ -11,27 +11,36 @@ ARG SEMGREP_VERSION
 WORKDIR /go/src/github.com/grafana/plugin-validator
 ADD . /go/src/github.com/grafana/plugin-validator
 
-RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip clamav
+# nodejs/npm are required by the reactcompat analyzer (npx @grafana/react-detect).
+# Pinned to Node 24.x to match the version used in release workflows.
+RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip clamav nodejs=24.14.1-r0 npm
 RUN update-ca-certificates
 RUN freshclam
 
+# Split into separate layers so each network operation is independently
+# cacheable and surfaces its own failure (instead of being lost in a 4-in-1 step).
 RUN git clone https://github.com/magefile/mage --depth 1 && \
     cd mage && \
-    go run bootstrap.go && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION} && \
-    curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b /usr/local/bin ${GOSEC_VERSION} && \
-    python3 -m pip install semgrep==${SEMGREP_VERSION} --ignore-installed --break-system-packages
+    go run bootstrap.go
+
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+    sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | \
+    sh -s -- -b /usr/local/bin ${GOSEC_VERSION}
+
+RUN python3 -m pip install semgrep==${SEMGREP_VERSION} --ignore-installed --break-system-packages
 
 RUN mage -v build:lint
 
 RUN mage -v build:ci
 
-FROM alpine:3.22@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 ARG GOSEC_VERSION
 ARG SEMGREP_VERSION
 
-RUN apk add --no-cache git ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav nodejs npm
+RUN apk add --no-cache git ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav nodejs=24.14.1-r0 npm
 RUN update-ca-certificates
 RUN freshclam
 

--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -96,6 +96,11 @@ func run(pass *analysis.Pass) (any, error) {
 	output, err := runReactDetect(npxPath, archiveDir)
 	if err != nil {
 		logme.DebugFln("react-detect failed: %v", err)
+		// Missing source maps is not a tool failure — it just means there's
+		// nothing to analyze (e.g. unbuilt plugin or empty archive). Skip silently.
+		if strings.Contains(err.Error(), "No source map files found") {
+			return nil, nil
+		}
 		pass.ReportResult(
 			pass.AnalyzerName,
 			react19Issue,
@@ -105,7 +110,7 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	issueCount := reportIssues(pass, output)
+	issueCount := reportIssues(pass, output, archiveDir)
 
 	if issueCount == 0 && react19Compatible.ReportAll {
 		pass.ReportResult(
@@ -120,27 +125,30 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 // runReactDetect shells out to react-detect and returns the parsed output.
-// --distDir points react-detect directly at the extracted archive directory,
-// avoiding the need for a symlink or temp directory.
+// The command's cwd is set to archiveDir so that react-detect resolves
+// source-map-relative paths against the archive (yielding paths like
+// <archiveDir>/src/...) rather than against the caller's cwd. The archive
+// prefix is stripped later in reportIssues for reproducible output.
 func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	// --json: machine-readable output. --skipBuildTooling: avoid running bundlers.
 	// --noErrorExitCode: always exit 0 so we can parse partial output on warnings.
-	// --distDir: point at the extracted archive directly (available since v0.6.4).
+	// --distDir: "." because we set cmd.Dir = archiveDir below.
 	// Dependency issues are intentionally included (no --skipDependencies).
 	args := []string{
 		"-y",
 		"@grafana/react-detect@" + reactDetectVersion,
 		"--json",
-		"--distDir", archiveDir,
+		"--distDir", ".",
 		"--skipBuildTooling",
 		"--noErrorExitCode",
 	}
 	logme.DebugFln("running react-detect with args: %v", args)
 
 	cmd := exec.CommandContext(ctx, npxPath, args...)
+	cmd.Dir = archiveDir
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
@@ -148,7 +156,9 @@ func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 		logme.DebugFln("react-detect stderr: %s", stderr.String())
 	}
 	if err != nil {
-		return nil, fmt.Errorf("react-detect exited with error: %w (stderr: %s)", err, stderr.String())
+		// react-detect writes user-facing errors to stdout, not stderr, so include
+		// both streams in the wrapped error for downstream detection.
+		return nil, fmt.Errorf("react-detect exited with error: %w (stdout: %s) (stderr: %s)", err, string(out), stderr.String())
 	}
 
 	return parseResults(out)
@@ -164,8 +174,9 @@ func parseResults(data []byte) (*reactDetectOutput, error) {
 }
 
 // reportIssues translates the react-detect output into pass diagnostics and
-// returns the total number of issues reported.
-func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
+// returns the total number of issues reported. archiveDir is stripped from
+// reported file paths so output is reproducible across machines.
+func reportIssues(pass *analysis.Pass, output *reactDetectOutput, archiveDir string) int {
 	// react19Issue serves as the config gate for all dynamic react-19 rules.
 	if react19Issue.Disabled {
 		return 0
@@ -191,7 +202,7 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 			}
 			detail := fmt.Sprintf(
 				"Detected in %s at line %d. %s See: %s Note: this may be a false positive.",
-				issue.Location.File,
+				relativeToArchive(issue.Location.File, archiveDir),
 				issue.Location.Line,
 				issue.Fix.Description,
 				issue.Link,
@@ -216,4 +227,18 @@ func reportIssues(pass *analysis.Pass, output *reactDetectOutput) int {
 	}
 
 	return count
+}
+
+// relativeToArchive strips the archive directory prefix from a file path
+// emitted by react-detect, so reported paths are reproducible across machines.
+// Falls back to the original path if it doesn't share the archive prefix.
+func relativeToArchive(file, archiveDir string) string {
+	if archiveDir == "" {
+		return file
+	}
+	prefix := strings.TrimRight(archiveDir, "/") + "/"
+	if strings.HasPrefix(file, prefix) {
+		return strings.TrimPrefix(file, prefix)
+	}
+	return file
 }

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -108,7 +108,7 @@ func TestReportIssuesSourceCode(t *testing.T) {
 		},
 	}
 
-	count := reportIssues(pass, output)
+	count := reportIssues(pass, output, "")
 	require.Equal(t, 1, count)
 	require.Len(t, interceptor.Diagnostics, 1)
 
@@ -141,7 +141,7 @@ func TestReportIssuesDependency(t *testing.T) {
 		},
 	}
 
-	count := reportIssues(pass, output)
+	count := reportIssues(pass, output, "")
 	require.Equal(t, 1, count)
 	require.Len(t, interceptor.Diagnostics, 1)
 
@@ -159,7 +159,7 @@ func TestReportIssuesNil(t *testing.T) {
 	var interceptor testpassinterceptor.TestPassInterceptor
 	pass := newPass(&interceptor, "/some/archive/dir")
 
-	count := reportIssues(pass, nil)
+	count := reportIssues(pass, nil, "")
 	require.Equal(t, 0, count)
 	require.Len(t, interceptor.Diagnostics, 0)
 }
@@ -219,7 +219,7 @@ func TestReportIssuesCombined(t *testing.T) {
 		},
 	}
 
-	count := reportIssues(pass, output)
+	count := reportIssues(pass, output, "")
 	require.Equal(t, 3, count)
 	require.Len(t, interceptor.Diagnostics, 3)
 

--- a/pkg/cmd/plugincheck2/main_test.go
+++ b/pkg/cmd/plugincheck2/main_test.go
@@ -141,6 +141,14 @@ func TestIntegration(t *testing.T) {
 							Name:     "code-diff-skipped",
 						},
 					},
+					"reactcompat": {
+						{
+							Severity: "warning",
+							Title:    "React 19 compatibility: Prop types removed in favour of typescript or other type-checking solution",
+							Detail:   "Affected packages: react-table-6. See: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis Note: this may be a false positive.",
+							Name:     "react-19-dep-propTypes",
+						},
+					},
 				},
 			},
 		},
@@ -157,6 +165,14 @@ func TestIntegration(t *testing.T) {
 							Title:    "You can include a sponsorship link if you want users to support your work",
 							Detail:   "Consider to add a sponsorship link in your plugin.json file (Info.Links section: with Name: 'sponsor' or Name: 'sponsorship'), which will be shown on the plugin details page to allow users to support your work if they wish.",
 							Name:     "sponsorshiplink",
+						},
+					},
+					"reactcompat": {
+						{
+							Severity: "warning",
+							Title:    "React 19 compatibility: Default props removed from function components",
+							Detail:   "Detected in src/components/extended/Space.tsx at line 21. Use ES6 default parameters or pass default values to dependencies to keep consistent behavior See: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis Note: this may be a false positive.",
+							Name:     "react-19-defaultProps",
 						},
 					},
 				},


### PR DESCRIPTION
Docker builder was missing nodejs/npm, so reactcompat skipped in CI but ran locally, and react-detect emitted machine-specific absolute paths.

Adds pinned nodejs 24.14.1-r0 + npm to both Dockerfile stages (bumps Alpine to 3.23 for Node 24), sets the command cwd to the archive dir so reported paths can be stripped to relative, and updates the integration test expectations.