### PR TITLE
chore(deps): bump step-security/harden-runner to v2.16.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
           github_app: grafana-plugins-platform-bot
 
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 


### PR DESCRIPTION
Bumps the `step-security/harden-runner` action in `.github/workflows/release-please.yml` from v2.13.1 to v2.16.0.

- `step-security/harden-runner`: v2.13.1 → v2.16.0