### PR TITLE
Switch npm packages to stage publishing

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -61,4 +61,4 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: cd mcp-package && npm install
-      - run: cd mcp-package && npm publish
+      - run: cd mcp-package && npm stage publish

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -62,3 +62,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: cd mcp-package && npm install
       - run: cd mcp-package && npm stage publish
+
+      - name: Notify Slack about staged npm package
+        uses: grafana/shared-workflows/actions/send-slack-message@eb1fbd807f87aea8f40ff08dc9cd02872cad55b3 # send-slack-message/v2.0.5
+        with:
+          method: chat.postMessage
+          payload: |
+            {
+              "channel": "C031SLFH6G0",
+              "text": "📦 `@grafana/plugin-validator-mcp` has been staged for npm publishing from tag `${{ github.ref_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm install
-      - run: npm publish
+      - run: npm stage publish
 
   release-to-dockerhub:
     runs-on: ubuntu-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,16 @@ jobs:
       - run: npm install
       - run: npm stage publish
 
+      - name: Notify Slack about staged npm package
+        uses: grafana/shared-workflows/actions/send-slack-message@eb1fbd807f87aea8f40ff08dc9cd02872cad55b3 # send-slack-message/v2.0.5
+        with:
+          method: chat.postMessage
+          payload: |
+            {
+              "channel": "C031SLFH6G0",
+              "text": "📦 `@grafana/plugin-validator` has been staged for npm publishing from tag `${{ github.ref_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
+            }
+
   release-to-dockerhub:
     runs-on: ubuntu-x64
     # this job doesn't really need the github release, but it is a fast


### PR DESCRIPTION
Changed: 
1. release.yml publishes plugincheck2; 
2. release-mcp.yml publishes @grafana/plugin-validator-mcp

Fixes: https://github.com/grafana/grafana-catalog-team/issues/995