### PR TITLE
fix(release): attach binaries to immutable releases via draft-then-publish

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,9 +1,29 @@
 name: Create MCP release and publish to github and npm
 
+# Reusable workflow invoked by release-please.yml once an MCP release has been
+# drafted. See release.yml for why this is driven from release-please's outputs
+# rather than a tag push (GitHub immutable releases + draft releases).
 on: # zizmor: ignore[cache-poisoning]
-  push:
-    tags:
-      - "mcp/v[0-9]*"
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Release tag, e.g. mcp/v0.1.3
+        required: true
+        type: string
+      sha:
+        description: Commit SHA the release points at
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag, e.g. mcp/v0.1.3
+        required: true
+        type: string
+      sha:
+        description: Commit SHA the release points at
+        required: true
+        type: string
 
 jobs:
   release-mcp-to-github:
@@ -14,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -29,7 +50,9 @@ jobs:
           github_app: grafana-plugins-platform-bot
 
       - name: Extract MCP version
-        run: echo "MCP_VERSION=${GITHUB_REF_NAME#mcp/v}" >> $GITHUB_ENV
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: echo "MCP_VERSION=${TAG_NAME#mcp/v}" >> "$GITHUB_ENV"
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
@@ -42,7 +65,7 @@ jobs:
           args: release --clean --config .goreleaser.mcp.yaml --skip=validate
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag_name }}
           MCP_VERSION: ${{ env.MCP_VERSION }}
 
   release-mcp-to-npm:
@@ -54,6 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -70,5 +94,5 @@ jobs:
           payload: |
             {
               "channel": "C031SLFH6G0",
-              "text": "📦 `@grafana/plugin-validator-mcp` has been staged for npm publishing from tag `${{ github.ref_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
+              "text": "📦 `@grafana/plugin-validator-mcp` has been staged for npm publishing from tag `${{ inputs.tag_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
             }

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          # This is a publishing workflow; disable the Go cache so a cache
+          # entry poisoned from a less-trusted context can't influence the
+          # released binaries (zizmor cache-poisoning).
+          cache: false
 
       - name: Generate token
         id: generate_token

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/release.yml
+    # Trusted same-repo reusable workflow; its steps authenticate via inherited
+    # org/OIDC context and reference no plaintext secrets, so inheriting is safe.
+    uses: ./.github/workflows/release.yml # zizmor: ignore[secrets-inherit]
     with:
       tag_name: ${{ needs.release-please.outputs.pv_tag_name }}
       sha: ${{ needs.release-please.outputs.pv_sha }}
@@ -77,7 +79,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/release-mcp.yml
+    # Trusted same-repo reusable workflow; its steps authenticate via inherited
+    # org/OIDC context and reference no plaintext secrets, so inheriting is safe.
+    uses: ./.github/workflows/release-mcp.yml # zizmor: ignore[secrets-inherit]
     with:
       tag_name: ${{ needs.release-please.outputs.mcp_tag_name }}
       sha: ${{ needs.release-please.outputs.mcp_sha }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,15 @@
 # Creates release PRs, tags, and GitHub Releases for plugin-validator and the
 # MCP server using release-please. Conventional commits on `main` drive the
-# version bumps and changelog content. The post-tag publish workflows
-# (release.yml, release-mcp.yml) handle GoReleaser builds, npm publishing, and
-# Docker image push.
+# version bumps and changelog content.
+#
+# release-please creates the GitHub Releases as *drafts* (see "draft": true in
+# release-please-config.json) because GitHub's immutable releases lock a release
+# the instant it is published, and GoReleaser needs to attach the binaries
+# first. A draft release neither pushes a git tag nor fires a `release` event,
+# so the publish workflows (release.yml, release-mcp.yml) can no longer be
+# triggered by a tag push — they are reusable workflows invoked here, gated on
+# release-please's per-package `release_created` outputs. GoReleaser then adopts
+# the draft, uploads the artifacts, and publishes it.
 name: Release Please
 
 on:
@@ -21,6 +28,13 @@ jobs:
       contents: write # create releases and tags
       pull-requests: write # create release PRs
       id-token: write
+    outputs:
+      pv_release_created: ${{ steps.release.outputs['.--release_created'] }}
+      pv_tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      pv_sha: ${{ steps.release.outputs['.--sha'] }}
+      mcp_release_created: ${{ steps.release.outputs['mcp-package--release_created'] }}
+      mcp_tag_name: ${{ steps.release.outputs['mcp-package--tag_name'] }}
+      mcp_sha: ${{ steps.release.outputs['mcp-package--sha'] }}
     steps:
       - name: Generate GitHub token
         id: generate-github-token
@@ -40,3 +54,31 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}
           token: ${{ steps.generate-github-token.outputs.token }}
+
+  # Build binaries, upload them to the drafted plugin-validator release, and
+  # publish it. Only runs on the push that merges the plugin-validator release
+  # PR (when release-please reports a release was created).
+  release-plugin-validator:
+    needs: release-please
+    if: needs.release-please.outputs.pv_release_created == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.pv_tag_name }}
+      sha: ${{ needs.release-please.outputs.pv_sha }}
+    secrets: inherit
+
+  # Same as above, for the MCP server release.
+  release-mcp:
+    needs: release-please
+    if: needs.release-please.outputs.mcp_release_created == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release-mcp.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.mcp_tag_name }}
+      sha: ${{ needs.release-please.outputs.mcp_sha }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          # This is a publishing workflow; disable the Go cache so a cache
+          # entry poisoned from a less-trusted context can't influence the
+          # released binaries (zizmor cache-poisoning).
+          cache: false
 
       - name: Generate token
         id: generate_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,32 @@
 name: Create release and publish to github, npm and docker hub
 
+# Reusable workflow invoked by release-please.yml once a plugin-validator
+# release has been drafted. It is NOT triggered by tag pushes: with GitHub's
+# immutable releases enabled, release-please creates the GitHub release as a
+# *draft* (which does not push a git tag and does not fire a `release` event),
+# so GoReleaser is driven from release-please's outputs instead. GoReleaser
+# adopts the draft, uploads the binaries, and then publishes it.
 on: # zizmor: ignore[cache-poisoning]
-  push:
-    tags:
-      - 'plugin-validator/v[0-9]*'
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Release tag, e.g. plugin-validator/v0.42.7
+        required: true
+        type: string
+      sha:
+        description: Commit SHA the release points at
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag, e.g. plugin-validator/v0.42.7
+        required: true
+        type: string
+      sha:
+        description: Commit SHA the release points at
+        required: true
+        type: string
 
 jobs:
   release-to-github:
@@ -14,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -30,7 +54,9 @@ jobs:
           github_app: grafana-plugins-platform-bot
 
       - name: Extract release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#plugin-validator/v}" >> "$GITHUB_ENV"
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: echo "RELEASE_VERSION=${TAG_NAME#plugin-validator/v}" >> "$GITHUB_ENV"
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
@@ -44,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag_name }}
 
   release-to-npm:
     runs-on: ubuntu-latest
@@ -55,6 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -71,7 +98,7 @@ jobs:
           payload: |
             {
               "channel": "C031SLFH6G0",
-              "text": "📦 `@grafana/plugin-validator` has been staged for npm publishing from tag `${{ github.ref_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
+              "text": "📦 `@grafana/plugin-validator` has been staged for npm publishing from tag `${{ inputs.tag_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
             }
 
   release-to-dockerhub:
@@ -85,6 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.sha }}
           persist-credentials: false
 
       - name: Get version from package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,8 @@ jobs:
             "v${{ steps.get_version.outputs.version }}"
             "latest"
           push: true
-          # No type=gha build cache on this publishing build: a cache seeded
-          # from a less-trusted context (e.g. a PR) must not be able to
-          # influence the published image (cache poisoning).
+          # Disable the build cache (the action defaults cache-from/to to
+          # type=gha): a cache seeded from a less-trusted context (e.g. a PR)
+          # must not be able to influence the published image (cache poisoning).
+          cache-from: ""
+          cache-to: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,5 +136,6 @@ jobs:
             "v${{ steps.get_version.outputs.version }}"
             "latest"
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No type=gha build cache on this publishing build: a cache seeded
+          # from a less-trusted context (e.g. a PR) must not be able to
+          # influence the published image (cache poisoning).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
           tags: |-
             "test-pr"
           push: false
-          # No type=gha build cache: this PR validation build must not seed a
-          # shared cache that a publishing build could later consume (cache
-          # poisoning), and the type=gha backend was failing to import anyway.
+          # Disable the build cache (the action defaults cache-from/to to
+          # type=gha): this PR validation build must not seed a shared cache a
+          # publishing build could later consume (cache poisoning), and the
+          # type=gha backend was failing to import anyway.
+          cache-from: ""
+          cache-to: ""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,5 +40,6 @@ jobs:
           tags: |-
             "test-pr"
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No type=gha build cache: this PR validation build must not seed a
+          # shared cache that a publishing build could later consume (cache
+          # poisoning), and the type=gha backend was failing to import anyway.

--- a/.goreleaser.mcp.yaml
+++ b/.goreleaser.mcp.yaml
@@ -37,4 +37,9 @@ changelog:
   disable: true
 
 release:
-  mode: keep-existing
+  # See .goreleaser.yaml for the rationale: release-please creates a draft
+  # release, GoReleaser uploads assets to it and then publishes it, so the
+  # binaries are attached before GitHub's immutable releases lock it.
+  mode: keep-existing # keep release-please's changelog notes
+  use_existing_draft: true # adopt the draft release-please created (GoReleaser >= v2.5)
+  replace_existing_artifacts: true # make re-runs idempotent (handles 422 already-exists)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,14 @@ changelog:
       - "^docs:"
       - "^test:"
 release:
-  mode: keep-existing
+  # release-please creates a *draft* GitHub release (with the changelog notes).
+  # GitHub's immutable releases lock a release the moment it is published, so
+  # assets must be attached while it is still a draft. GoReleaser adopts that
+  # draft, uploads the binaries, and then publishes it (draft defaults to
+  # false), which is the only upload order GitHub's immutable releases allow.
+  mode: keep-existing # keep release-please's changelog notes
+  use_existing_draft: true # adopt the draft release-please created (GoReleaser >= v2.5)
+  replace_existing_artifacts: true # make re-runs idempotent (handles 422 already-exists)
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,12 +47,7 @@ RUN mage -v build:lint
 
 RUN mage -v build:ci
 
-# TODO: revert to alpine:3.23 (latest, currently 3.23.4 @sha256:5b10f432…) once
-# the self-hosted runner's Docker Hub pull-through mirror is repaired. Pinned to
-# 3.23.3 because the mirror serves a corrupted/truncated copy of 3.23.4's rootfs
-# layer (0 bytes / "unexpected EOF"); the layer is intact on docker.io. 3.23.3
-# is a different build (different layer blob) so the mirror fetches it cleanly.
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 ARG GOSEC_VERSION
 ARG SEMGREP_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,12 @@ RUN mage -v build:lint
 
 RUN mage -v build:ci
 
-FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+# TODO: revert to alpine:3.23 (latest, currently 3.23.4 @sha256:5b10f432…) once
+# the self-hosted runner's Docker Hub pull-through mirror is repaired. Pinned to
+# 3.23.3 because the mirror serves a corrupted/truncated copy of 3.23.4's rootfs
+# layer (0 bytes / "unexpected EOF"); the layer is intact on docker.io. 3.23.3
+# is a different build (different layer blob) so the mirror fetches it cleanly.
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 ARG GOSEC_VERSION
 ARG SEMGREP_VERSION

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,11 +20,13 @@
       "package-name": "plugin-validator",
       "release-type": "node",
       "exclude-paths": ["mcp-package"],
-      "bootstrap-sha": "627dd9babe0a4244226ed98208aeccbd319a572f"
+      "bootstrap-sha": "627dd9babe0a4244226ed98208aeccbd319a572f",
+      "draft": true
     },
     "mcp-package": {
       "package-name": "mcp",
-      "release-type": "node"
+      "release-type": "node",
+      "draft": true
     }
   },
   "tag-separator": "/",


### PR DESCRIPTION
## Problem

Recent releases are published with **no binaries** — e.g. [`plugin-validator/v0.42.6`](https://github.com/grafana/plugin-validator/releases/tag/plugin-validator%2Fv0.42.6) and `v0.42.2` have zero assets. This breaks consumers that download `plugincheck2` from the release assets.

### Root cause

This repo has **release immutability** enabled (*"Disallow assets and tags from being modified once a release is published"*). Our release flow is two-step:

1. `release-please` (on merge to `main`) creates the tag **and a _published_ GitHub Release** with changelog notes — but no binaries.
2. `release.yml` / `release-mcp.yml` (on tag push, GoReleaser `mode: keep-existing`) build the archives and **append** them to that release.

With immutability on, step 1's release is locked the instant it's published, so step 2's uploads all fail. From the `v0.42.6` GoReleaser job ([run](https://github.com/grafana/plugin-validator/actions/runs/26635279114)):

```
• scm releases
  • uploading to release  name=plugin-validator_0.42.6_linux_amd64.tar.gz
  • upload failed  error=POST .../releases/331478222/assets: 422 Cannot upload assets to an immutable release.
⨯ release failed: scm releases: failed to publish artifacts: ... 422 Cannot upload assets to an immutable release.
```

`v0.42.5` (May 28) succeeded; `v0.42.6` (May 29) is the first to fail — immutability was switched on in between.

## Fix

GitHub's immutable releases only allow one upload order: **attach assets while the release is a draft, then publish.** This PR implements exactly that:

1. **`release-please-config.json`** — `"draft": true` on both packages, so release-please creates the GitHub Release as a **draft** (mutable; notes only).
2. **`.goreleaser.yaml` / `.goreleaser.mcp.yaml`** — `use_existing_draft: true` (GoReleaser ≥ v2.5) + `replace_existing_artifacts: true`. GoReleaser adopts release-please's draft, uploads the binaries, then publishes it (draft defaults to `false`). `mode: keep-existing` preserves release-please's notes.
3. **Trigger move** — a draft release **pushes no git tag** and **fires no `release` event** ([ref](https://github.com/orgs/community/discussions/7118)), so the old `on: push: tags` triggers can never fire. `release.yml` and `release-mcp.yml` are now **reusable workflows** (`workflow_call`), invoked from `release-please.yml` gated on the per-package `*--release_created` outputs, building from the release `*--sha`. A `workflow_dispatch` trigger is added to each for manual re-runs.

### Resulting flow
```
push to main → release-please → (draft release + notes, no tag)
                     │ outputs: <pkg>--release_created / tag_name / sha
                     ▼
        reusable release workflow → goreleaser: adopt draft → upload binaries → publish
                     ▼
        GitHub creates the tag at publish; release is now immutable WITH binaries
```

## Validation done
- JSON + YAML parse; `actionlint` clean on all three workflows (only pre-existing self-hosted runner-label warnings).
- Output key names (`.--release_created`, `.--tag_name`, `.--sha`, `mcp-package--*`) per the release-please-action README.
- `use_existing_draft` / `replace_existing_artifacts` / `mode` per the GoReleaser release docs.

## Please confirm during review / first release
- A release pipeline can't be fully exercised without cutting a release. Worth watching the first post-merge release closely.
- `use_existing_draft` matches release-please's draft by tag name, and publishing creates the tag at the intended commit (GoReleaser's `target_commitish` defaults to the checked-out `{{ .Commit }}` = the release `sha` we pass).
- `version: latest` for GoReleaser must resolve to ≥ v2.5 for `use_existing_draft` (it does today).

## Recovering v0.42.6
Already published & immutable, so it can't be backfilled — it needs a new patch release once this merges. Consumers should also fall back gracefully to the newest release that has assets (a companion fix is going into community-pipeline).
