### PR TITLE
fix(release): use un-prefixed release-please outputs for root component

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,12 @@ jobs:
       pull-requests: write # create release PRs
       id-token: write
     outputs:
-      pv_release_created: ${{ steps.release.outputs['.--release_created'] }}
-      pv_tag_name: ${{ steps.release.outputs['.--tag_name'] }}
-      pv_sha: ${{ steps.release.outputs['.--sha'] }}
+      # plugin-validator is the root component (path "."), so release-please-action
+      # emits its outputs UN-prefixed (release_created/tag_name/sha) — not
+      # ".--release_created". Only non-root packages get the "<path>--" prefix.
+      pv_release_created: ${{ steps.release.outputs.release_created }}
+      pv_tag_name: ${{ steps.release.outputs.tag_name }}
+      pv_sha: ${{ steps.release.outputs.sha }}
       mcp_release_created: ${{ steps.release.outputs['mcp-package--release_created'] }}
       mcp_tag_name: ${{ steps.release.outputs['mcp-package--tag_name'] }}
       mcp_sha: ${{ steps.release.outputs['mcp-package--sha'] }}


### PR DESCRIPTION
## Problem

When release PR #603 (`release plugin-validator 0.42.7`) was merged, release-please created the **draft** v0.42.7 release correctly, but the `release-plugin-validator` job was **skipped**, so GoReleaser never ran and the draft was never published with binaries.

Root cause: release-please-action emits outputs for the **root component** (path `.`) **without** the `<path>--` prefix. So `steps.release.outputs['.--release_created']` was always empty and the gating `if: ... pv_release_created == 'true'` never matched. (Confirmed against the [action docs](https://github.com/googleapis/release-please-action#outputs): *"If you have a root component (path is `.` or unset), then the action will also output: `release_created`, `tag_name`, …"* — un-prefixed.)

## Fix

Use the un-prefixed outputs for the root `plugin-validator` component:

```yaml
pv_release_created: ${{ steps.release.outputs.release_created }}
pv_tag_name:        ${{ steps.release.outputs.tag_name }}
pv_sha:             ${{ steps.release.outputs.sha }}
```

`mcp-package` is a non-root path, so its `mcp-package--*` keys were already correct and are unchanged.

## Note on v0.42.7

v0.42.7's draft already existed, so it was published with binaries out-of-band via the `release.yml` `workflow_dispatch` recovery path (adopting the existing draft). This PR ensures the **next** release auto-publishes without manual intervention. Validated with actionlint + zizmor.
