### PR TITLE
fix(release): adopt release-please draft, drop goreleaser changelog, fix npm publish

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -58,7 +58,7 @@ jobs:
           TAG_NAME: ${{ inputs.tag_name }}
         run: echo "MCP_VERSION=${TAG_NAME#mcp/v}" >> "$GITHUB_ENV"
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: latest
@@ -88,6 +88,9 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      # Staged publishing requires npm >= 11.15.0, newer than the npm bundled
+      # with Node 24.
+      - run: npm install -g npm@latest
       - run: cd mcp-package && npm install
       - run: cd mcp-package && npm stage publish
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           TAG_NAME: ${{ inputs.tag_name }}
         run: echo "RELEASE_VERSION=${TAG_NAME#plugin-validator/v}" >> "$GITHUB_ENV"
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: latest
@@ -92,6 +92,9 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      # Staged publishing requires npm >= 11.15.0, newer than the npm bundled
+      # with Node 24.
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm stage publish
 

--- a/.goreleaser.mcp.yaml
+++ b/.goreleaser.mcp.yaml
@@ -40,6 +40,11 @@ release:
   # See .goreleaser.yaml for the rationale: release-please creates a draft
   # release, GoReleaser uploads assets to it and then publishes it, so the
   # binaries are attached before GitHub's immutable releases lock it.
+  #
+  # name_template must equal release-please's release name ("<package-name>:
+  # v<version>") so use_existing_draft adopts the draft instead of creating a
+  # duplicate release.
+  name_template: "mcp: v{{ .Env.MCP_VERSION }}"
   mode: keep-existing # keep release-please's changelog notes
   use_existing_draft: true # adopt the draft release-please created (GoReleaser >= v2.5)
   replace_existing_artifacts: true # make re-runs idempotent (handles 422 already-exists)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,17 +30,22 @@ checksum:
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
+  # release-please owns the changelog/release notes. GoReleaser's own changelog
+  # can't determine a "previous tag" from the non-semver plugin-validator/v* tags
+  # (we pass --skip=validate), so it would dump a huge commit range. Disable it.
+  disable: true
 release:
   # release-please creates a *draft* GitHub release (with the changelog notes).
   # GitHub's immutable releases lock a release the moment it is published, so
   # assets must be attached while it is still a draft. GoReleaser adopts that
   # draft, uploads the binaries, and then publishes it (draft defaults to
   # false), which is the only upload order GitHub's immutable releases allow.
+  #
+  # use_existing_draft matches the draft by release NAME (name_template), so this
+  # must equal release-please's release name ("<package-name>: v<version>") or
+  # GoReleaser won't find the draft and will create a duplicate release with its
+  # own notes instead of keeping release-please's.
+  name_template: "plugin-validator: v{{ .Env.RELEASE_VERSION }}"
   mode: keep-existing # keep release-please's changelog notes
   use_existing_draft: true # adopt the draft release-please created (GoReleaser >= v2.5)
   replace_existing_artifacts: true # make re-runs idempotent (handles 422 already-exists)


### PR DESCRIPTION
## Context

Follow-ups found while verifying the first real release (v0.42.7) through the new immutable-release flow (#602). The core flow works (v0.42.7 shipped with all 9 binaries), but the run surfaced four issues.

## Fixes

**1. GoReleaser created a duplicate release with a huge changelog**
GoReleaser didn't adopt release-please's draft — `use_existing_draft` matches the draft by release **name**, and GoReleaser defaulted to the tag (`plugin-validator/v0.42.7`) while release-please names the release `plugin-validator: v0.42.7`. So it created a second release with its own commit-dump changelog (the tags aren't semver, so it can't find a "previous tag").
→ Set `release.name_template: "plugin-validator: v{{ .Env.RELEASE_VERSION }}"` (and `"mcp: v{{ .Env.MCP_VERSION }}"`) so the draft is adopted, keeping release-please's curated notes and avoiding duplicates.

**2. Disable GoReleaser's changelog**
release-please owns the changelog. Belt-and-suspenders against the huge commit dump even if adoption ever misses.

**3. npm staged publish failed**
`npm stage publish` needs npm ≥ 11.15.0, newer than the npm bundled with Node 24.
→ `npm install -g npm@latest` before publishing in both release jobs.

**4. Bump `goreleaser-action` v6.4.0 → v7.2.2**
Runs on Node 24; clears the Node 20 deprecation warning.

## Validation

actionlint + zizmor clean. The draft-adoption and changelog behavior can only be fully confirmed on the next real release (0.43.0) — worth watching that the published release has release-please's short notes and there's no orphan draft.
