### PR TITLE
chore(ci): bump release-please-action to v5.0.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

Bumps `googleapis/release-please-action` from `v4.4.1` to `v5.0.0` in `.github/workflows/release-please.yml`, keeping the SHA-pin convention used across the repo (`5c625bf…` → `45996ed…`).

## v5.0.0 notes

- ⚠️ The only breaking change is the **Node 24 runtime** upgrade ([#1188](https://github.com/googleapis/release-please-action/issues/1188)). The action's inputs/outputs are unchanged, so `config-file`, `manifest-file`, `target-branch`, `token`, and the `release_created`/`tag_name`/`sha` outputs this workflow relies on all continue to work.
- Bundles a release-please core bump (17.3.0 → 17.6.0).

The `ubuntu-arm64-small` runner ships Node 24, so the runtime upgrade is a non-issue.

## Test plan

- [ ] CI passes on this PR.
- [ ] Next merge to `main` produces the expected release PR / draft release.