### PR TITLE
fix(provenance): use repo-scoped attestation endpoint

### DIFF
--- a/pkg/analysis/passes/provenance/provenance.go
+++ b/pkg/analysis/passes/provenance/provenance.go
@@ -70,6 +70,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	owner := matches[1]
+	repo := matches[2]
 	ctx, canc := context.WithTimeout(context.Background(), time.Second*30)
 	defer canc()
 
@@ -77,6 +78,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		ctx,
 		pass.CheckParams.ArchiveFile,
 		owner,
+		repo,
 	)
 	if err != nil || !hasGithubProvenanceAttestationPipeline {
 		message := "Cannot verify plugin build provenance attestation."
@@ -106,13 +108,19 @@ func hasGithubProvenanceAttestationPipeline(
 	ctx context.Context,
 	assetPath string,
 	owner string,
+	repo string,
 ) (bool, error) {
 	sha256sum, err := getFileSha256(assetPath)
 	if err != nil {
 		return false, err
 	}
 
-	url := fmt.Sprintf("https://api.github.com/users/%s/attestations/sha256:%s", owner, sha256sum)
+	url := fmt.Sprintf(
+		"https://api.github.com/repos/%s/%s/attestations/sha256:%s",
+		owner,
+		repo,
+		sha256sum,
+	)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

The provenance attestation check fails for plugins published under a GitHub **organization**, even when the plugin was correctly built with provenance attestation.

The check queried the **user-scoped** attestations endpoint:

```
GET /users/{owner}/attestations/sha256:{digest}
```

This endpoint only returns attestations for repositories owned by a *user account*. For organization-owned repositories it returns 404, so the validator reported a false `invalid-provenance-attestation`.

This switches to the **repository-scoped** endpoint, which works for both user- and organization-owned repositories:

```
GET /repos/{owner}/{repo}/attestations/sha256:{digest}
```

The repo name is already captured by the existing source-code-reference regex (`matches[2]`), so it's just threaded through to the request.

### Example

`kineticadb/grafana-kinetica-datasource` v1.0.5 (org-owned, correctly attested) was failing the check:

- `GET /users/kineticadb/attestations/sha256:<zip-digest>` → 404 (false failure)
- `GET /repos/kineticadb/grafana-kinetica-datasource/attestations/sha256:<zip-digest>` → 200 (attestation found, digest matches)

This affected effectively all plugins published under a GitHub org (most vendor plugins); only personal-account repositories worked before.
