### PR TITLE
fix(release): skip next release PR on release merges

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,10 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: ${{ github.ref_name }}
           token: ${{ steps.generate-github-token.outputs.token }}
+          # On a release PR merge, release-please must still create the draft
+          # GitHub Release for GoReleaser to adopt, but it must not calculate
+          # the next release PR before GoReleaser publishes the draft/tag.
+          skip-github-pull-request: "${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
 
   # Build binaries, upload them to the drafted plugin-validator release, and
   # publish it. Only runs on the push that merges the plugin-validator release


### PR DESCRIPTION
Prevents Release Please from opening the next release PR in the same run that creates the draft release for GoReleaser.

GoReleaser still gets the draft release to adopt and publish, but Release Please waits for a later main push before calculating the next release PR, after the tag exists.