### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>grafana/grafana-community-team//renovate/renovate"
+    "github>grafana/grafana-catalog-team//renovate/renovate"
+  ],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "github>grafana/grafana-renovate-config//presets/automerge",
+    "github>grafana/grafana-renovate-config//presets/labels",
+    "github>grafana/grafana-renovate-config//presets/npm"
   ],
   "packageRules": [
     {
@@ -54,6 +60,9 @@
     "dependencies"
   ],
   "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    ".config/**",
     "**/testdata/**"
   ]
 }


### PR DESCRIPTION
Point the Renovate config at the team preset's new path (the old grafana-community-team repo was renamed to grafana-catalog-team) and add the standard ignorePresets block. The ignorePresets has to live in this repo file because Renovate does not inherit it from an extended preset (renovatebot/renovate#14818), so it turns off the base, automerge, labels, and npm presets that the org-wide config already pulls in. The repo-level ignorePaths replaces the preset's rather than merging, so the list now carries the built-in defaults (node_modules, bower_components) and .config/** alongside the existing testdata entry. The Go, Dockerfile, and GitHub Actions grouping rules, the Go-version bump rule, and labels are unchanged.

Part of grafana/grafana-catalog-team#1052.