### PR TITLE
fix(docker): widen alpine nodejs pin to major version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ WORKDIR /go/src/github.com/grafana/plugin-validator
 ADD . /go/src/github.com/grafana/plugin-validator
 
 # nodejs/npm are required by the reactcompat analyzer (npx @grafana/react-detect).
-# Pinned to Node 24.x to match the version used in release workflows.
-RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip clamav nodejs=24.17.0-r0 npm
+# Pinned to Node 24.x to match the version used in release workflows. Fuzzy pin
+# (=~24) because Alpine drops old package revisions from its repo, so an exact
+# pin breaks every time Alpine bumps nodejs within the branch.
+RUN apk add --no-cache git ca-certificates curl python3 python3-dev py3-pip clamav 'nodejs=~24' npm
 RUN update-ca-certificates
 RUN freshclam
 
@@ -65,7 +67,7 @@ ARG GOSEC_VERSION
 ARG SEMGREP_VERSION
 
 # govulncheck source mode shells out to the Go command to load packages.
-RUN apk add --no-cache git go ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav nodejs=24.17.0-r0 npm
+RUN apk add --no-cache git go ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav 'nodejs=~24' npm
 RUN update-ca-certificates
 RUN freshclam
 


### PR DESCRIPTION
The docker build is broken on main and every PR: the Dockerfile pins `nodejs=24.17.0-r0` but Alpine has moved to 24.18.1-r0 and removed the old revision from its repo, so apk can no longer resolve the pin. Same failure mode as #621.

Switch both apk lines to a fuzzy pin (`nodejs=~24`). That keeps the major fixed for the reactcompat analyzer while tolerating Alpine's patch bumps within the branch, so this stops rotting. If a base image bump ever moves to an Alpine release shipping a new nodejs major, the build fails loudly and we decide consciously.