### PR TITLE
chore(ci): post release notifications to #grafana-catalog-ci

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -100,6 +100,6 @@ jobs:
           method: chat.postMessage
           payload: |
             {
-              "channel": "C031SLFH6G0",
+              "channel": "C0BNRK96T24",
               "text": "📦 `@grafana/plugin-validator-mcp` has been staged for npm publishing from tag `${{ inputs.tag_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           method: chat.postMessage
           payload: |
             {
-              "channel": "C031SLFH6G0",
+              "channel": "C0BNRK96T24",
               "text": "📦 `@grafana/plugin-validator` has been staged for npm publishing from tag `${{ inputs.tag_name }}`. Please review and approve at https://www.npmjs.com/settings/grafanabot/staged-packages"
             }
 


### PR DESCRIPTION
The team CI channel moved from #grafana-plugins-platform-ci to #grafana-catalog-ci. Updates the Slack channel ID in the release workflows (C031SLFH6G0 to C0BNRK96T24).