### PR TITLE
fix(reactcompat): bound react-detect output

### DIFF
--- a/pkg/analysis/passes/reactcompat/reactcompat.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat.go
@@ -16,9 +16,18 @@ import (
 	"github.com/grafana/plugin-validator/pkg/logme"
 )
 
-// reactDetectVersion is the pinned version of @grafana/react-detect.
-// Bump intentionally when adopting new detection rules.
-const reactDetectVersion = "0.6.4"
+const (
+	// reactDetectVersion is the pinned version of @grafana/react-detect.
+	// Bump intentionally when adopting new detection rules.
+	reactDetectVersion = "0.6.4"
+	// Limit each react-detect result so downstream payloads remain bounded.
+	maxReportBytes                = 32 * 1024
+	maxSummaryDiagnosticBytes     = 1024
+	maxCombinedStreamPreviewBytes = 30 * 1024
+	maxDebugStreamPreviewBytes    = 8 * 1024
+	maxStdoutCaptureBytes         = 16 * 1024 * 1024
+	maxStderrCaptureBytes         = 1024 * 1024
+)
 
 var (
 	react19Issue = &analysis.Rule{
@@ -79,6 +88,31 @@ type dependencyIssue struct {
 	PackageNames []string `json:"packageNames"`
 }
 
+// cappedBuffer accepts all writes but retains only the configured byte limit.
+type cappedBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buf.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		b.truncated = true
+		return len(p), nil
+	}
+	return b.buf.Write(p)
+}
+
+func (b *cappedBuffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
 func run(pass *analysis.Pass) (any, error) {
 	archiveDir, ok := pass.ResultOf[archive.Analyzer].(string)
 	if !ok || archiveDir == "" {
@@ -102,12 +136,7 @@ func run(pass *analysis.Pass) (any, error) {
 		if strings.Contains(err.Error(), "No source map files found") {
 			return nil, nil
 		}
-		pass.ReportResult(
-			pass.AnalyzerName,
-			react19Issue,
-			"React 19 compatibility: skipped (react-detect failed)",
-			fmt.Sprintf("react-detect could not be executed: %v", err),
-		)
+		reportExecutionFailure(pass, err)
 		return nil, nil
 	}
 
@@ -150,23 +179,86 @@ func runReactDetect(npxPath, archiveDir string) (*reactDetectOutput, error) {
 
 	cmd := exec.CommandContext(ctx, npxPath, args...)
 	cmd.Dir = archiveDir
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if stderr.Len() > 0 {
-		logme.DebugFln("react-detect stderr: %s", stderr.String())
+	stdout := &cappedBuffer{limit: maxStdoutCaptureBytes}
+	stderr := &cappedBuffer{limit: maxStderrCaptureBytes}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	out := stdout.Bytes()
+	if len(stderr.Bytes()) > 0 {
+		logme.DebugFln("react-detect stderr: %s", streamPreview(stderr.Bytes(), maxDebugStreamPreviewBytes))
+	}
+	if stdout.truncated {
+		captureErr := fmt.Errorf("stdout exceeded the %d byte capture limit", maxStdoutCaptureBytes)
+		if err != nil {
+			captureErr = fmt.Errorf("%w; %v", err, captureErr)
+		}
+		return nil, formatExecutionError(captureErr, out, stderr.Bytes())
 	}
 	if err != nil {
-		// react-detect writes user-facing errors to stdout, not stderr, so include
-		// both streams in the wrapped error for downstream detection.
-		return nil, fmt.Errorf("react-detect exited with error: %w (stdout: %s) (stderr: %s)", err, string(out), stderr.String())
+		output, parseErr := parseResults(out)
+		if parseErr == nil {
+			logme.DebugFln(
+				"react-detect exited with error after writing valid JSON: %v (stdout: %d bytes)",
+				err,
+				len(out),
+			)
+			return output, nil
+		}
+		return nil, formatExecutionError(err, out, stderr.Bytes())
 	}
 
 	return parseResults(out)
 }
 
+func formatExecutionError(runErr error, stdout, stderr []byte) error {
+	stdoutLimit, stderrLimit := streamPreviewLimits(len(stdout), len(stderr))
+	return fmt.Errorf(
+		"react-detect exited with error: %w (stdout: %s) (stderr: %s)",
+		runErr,
+		streamPreview(stdout, stdoutLimit),
+		streamPreview(stderr, stderrLimit),
+	)
+}
+
+func streamPreviewLimits(stdoutBytes, stderrBytes int) (int, int) {
+	half := maxCombinedStreamPreviewBytes / 2
+	stdoutLimit := min(stdoutBytes, half)
+	stderrLimit := min(stderrBytes, half)
+	remaining := maxCombinedStreamPreviewBytes - stdoutLimit - stderrLimit
+
+	stdoutExtra := min(stdoutBytes-stdoutLimit, remaining)
+	stdoutLimit += stdoutExtra
+	remaining -= stdoutExtra
+	stderrLimit += min(stderrBytes-stderrLimit, remaining)
+	return stdoutLimit, stderrLimit
+}
+
+func streamPreview(data []byte, limit int) string {
+	if len(data) == 0 {
+		return "empty"
+	}
+	if len(data) <= limit {
+		return fmt.Sprintf("%d bytes: %s", len(data), data)
+	}
+	return fmt.Sprintf("%d bytes: %s...[truncated]", len(data), data[:limit])
+}
+
 // parseResults unmarshals the raw JSON bytes from react-detect.
 func parseResults(data []byte) (*reactDetectOutput, error) {
+	var fields struct {
+		SourceCodeIssues json.RawMessage `json:"sourceCodeIssues"`
+		DependencyIssues json.RawMessage `json:"dependencyIssues"`
+	}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, fmt.Errorf("parse react-detect output: %w", err)
+	}
+	if len(fields.SourceCodeIssues) == 0 || len(fields.DependencyIssues) == 0 ||
+		bytes.Equal(bytes.TrimSpace(fields.SourceCodeIssues), []byte("null")) ||
+		bytes.Equal(bytes.TrimSpace(fields.DependencyIssues), []byte("null")) {
+		return nil, fmt.Errorf("parse react-detect output: missing required result fields")
+	}
+
 	var output reactDetectOutput
 	if err := json.Unmarshal(data, &output); err != nil {
 		return nil, fmt.Errorf("parse react-detect output: %w", err)
@@ -174,60 +266,166 @@ func parseResults(data []byte) (*reactDetectOutput, error) {
 	return &output, nil
 }
 
+func reportExecutionFailure(pass *analysis.Pass, runErr error) {
+	diagnostic := analysis.Diagnostic{
+		Name:     react19Issue.Name,
+		Severity: react19Issue.Severity,
+		Title:    "React 19 compatibility: skipped (react-detect failed)",
+		Detail:   fmt.Sprintf("react-detect could not be executed: %v", runErr),
+	}
+	diagnostic = limitDiagnosticSize(diagnostic, maxReportBytes-2)
+	reportDiagnostic(pass, diagnostic)
+}
+
+func reportDiagnostic(pass *analysis.Pass, diagnostic analysis.Diagnostic) {
+	if react19Issue.Disabled {
+		return
+	}
+	pass.ReportResult(
+		pass.AnalyzerName,
+		&analysis.Rule{Name: diagnostic.Name, Severity: diagnostic.Severity},
+		diagnostic.Title,
+		diagnostic.Detail,
+	)
+}
+
+func diagnosticJSONSize(diagnostic analysis.Diagnostic) int {
+	data, err := json.Marshal(diagnostic)
+	if err != nil {
+		return maxReportBytes + 1
+	}
+	return len(data)
+}
+
+func diagnosticsJSONSize(diagnostics []analysis.Diagnostic) int {
+	data, err := json.Marshal(diagnostics)
+	if err != nil {
+		return maxReportBytes + 1
+	}
+	return len(data)
+}
+
+func limitDiagnosticSize(diagnostic analysis.Diagnostic, maxBytes int) analysis.Diagnostic {
+	if diagnosticJSONSize(diagnostic) <= maxBytes {
+		return diagnostic
+	}
+
+	const marker = "\n...[truncated]"
+	detail := []rune(diagnostic.Detail)
+	low, high := 0, len(detail)
+	for low < high {
+		mid := (low + high + 1) / 2
+		candidate := diagnostic
+		candidate.Detail = string(detail[:mid]) + marker
+		if diagnosticJSONSize(candidate) <= maxBytes {
+			low = mid
+		} else {
+			high = mid - 1
+		}
+	}
+	diagnostic.Detail = string(detail[:low]) + marker
+	return diagnostic
+}
+
 // reportIssues translates the react-detect output into pass diagnostics and
-// returns the total number of issues reported. archiveDir is stripped from
-// reported file paths so output is reproducible across machines.
+// returns the total number of detected issues before the report size limit.
+// archiveDir is stripped from reported file paths so output is reproducible.
 func reportIssues(pass *analysis.Pass, output *reactDetectOutput, archiveDir string) int {
 	// react19Issue serves as the config gate for all dynamic react-19 rules.
-	if react19Issue.Disabled {
+	if react19Issue.Disabled || output == nil {
 		return 0
 	}
 
+	diagnostics := issueDiagnostics(output, archiveDir)
+	total := len(diagnostics)
+	if diagnosticsJSONSize(diagnostics) > maxReportBytes {
+		diagnostics = limitIssueDiagnostics(diagnostics)
+	}
+	for _, diagnostic := range diagnostics {
+		reportDiagnostic(pass, diagnostic)
+	}
+	return total
+}
+
+func limitIssueDiagnostics(diagnostics []analysis.Diagnostic) []analysis.Diagnostic {
+	const arrayJSONBytes = 2
+	issueBudget := maxReportBytes - maxSummaryDiagnosticBytes - arrayJSONBytes - 1
+	used := 0
+	reported := 0
+	for _, diagnostic := range diagnostics {
+		size := diagnosticJSONSize(diagnostic)
+		if reported > 0 {
+			size++
+		}
+		if used+size > issueBudget {
+			break
+		}
+		used += size
+		reported++
+	}
+
+	omitted := len(diagnostics) - reported
+	summary := limitDiagnosticSize(analysis.Diagnostic{
+		Name:     react19Issue.Name,
+		Severity: react19Issue.Severity,
+		Title:    "React 19 compatibility: results truncated",
+		Detail: fmt.Sprintf(
+			"Reported %d of %d issues. %d issues were omitted because react-detect reports are limited to %d bytes.",
+			reported,
+			len(diagnostics),
+			omitted,
+			maxReportBytes,
+		),
+	}, maxSummaryDiagnosticBytes)
+
+	limited := make([]analysis.Diagnostic, 0, reported+1)
+	limited = append(limited, diagnostics[:reported]...)
+	return append(limited, summary)
+}
+
+func issueDiagnostics(output *reactDetectOutput, archiveDir string) []analysis.Diagnostic {
 	if output == nil {
-		return 0
+		return nil
 	}
 
-	count := 0
-
+	var diagnostics []analysis.Diagnostic
 	patterns := make([]string, 0, len(output.SourceCodeIssues))
-	for p := range output.SourceCodeIssues {
-		patterns = append(patterns, p)
+	for pattern := range output.SourceCodeIssues {
+		patterns = append(patterns, pattern)
 	}
 	slices.Sort(patterns)
 
 	for _, pattern := range patterns {
 		for _, issue := range output.SourceCodeIssues[pattern] {
-			rule := &analysis.Rule{
+			diagnostics = append(diagnostics, analysis.Diagnostic{
 				Name:     fmt.Sprintf("react-19-%s", issue.Pattern),
 				Severity: react19Issue.Severity,
-			}
-			detail := fmt.Sprintf(
-				"Detected in %s at line %d. %s See: %s Note: this may be a false positive.",
-				relativeToArchive(issue.Location.File, archiveDir),
-				issue.Location.Line,
-				issue.Fix.Description,
-				issue.Link,
-			)
-			pass.ReportResult(pass.AnalyzerName, rule, "React 19 compatibility: "+issue.Problem, detail)
-			count++
+				Title:    "React 19 compatibility: " + issue.Problem,
+				Detail: fmt.Sprintf(
+					"Detected in %s at line %d. %s See: %s Note: this may be a false positive.",
+					relativeToArchive(issue.Location.File, archiveDir),
+					issue.Location.Line,
+					issue.Fix.Description,
+					issue.Link,
+				),
+			})
 		}
 	}
 
 	for _, issue := range output.DependencyIssues {
-		rule := &analysis.Rule{
+		diagnostics = append(diagnostics, analysis.Diagnostic{
 			Name:     fmt.Sprintf("react-19-dep-%s", issue.Pattern),
 			Severity: react19Issue.Severity,
-		}
-		detail := fmt.Sprintf(
-			"Affected packages: %s. See: %s Note: this may be a false positive.",
-			strings.Join(issue.PackageNames, ", "),
-			issue.Link,
-		)
-		pass.ReportResult(pass.AnalyzerName, rule, "React 19 compatibility: "+issue.Problem, detail)
-		count++
+			Title:    "React 19 compatibility: " + issue.Problem,
+			Detail: fmt.Sprintf(
+				"Affected packages: %s. See: %s Note: this may be a false positive.",
+				strings.Join(issue.PackageNames, ", "),
+				issue.Link,
+			),
+		})
 	}
 
-	return count
+	return diagnostics
 }
 
 // relativeToArchive strips the archive directory prefix from a file path

--- a/pkg/analysis/passes/reactcompat/reactcompat_test.go
+++ b/pkg/analysis/passes/reactcompat/reactcompat_test.go
@@ -1,8 +1,10 @@
 package reactcompat
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -86,6 +88,21 @@ func TestParseResultsEmpty(t *testing.T) {
 func TestParseResultsMalformed(t *testing.T) {
 	_, err := parseResults([]byte(`not valid json {{{`))
 	require.Error(t, err)
+}
+
+func TestParseResultsRejectsJSONWithoutResultFields(t *testing.T) {
+	for _, payload := range []string{
+		`null`,
+		`{}`,
+		`{"error":"No source map files found"}`,
+		`{"sourceCodeIssues":null,"dependencyIssues":[]}`,
+		`{"sourceCodeIssues":{},"dependencyIssues":null}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			_, err := parseResults([]byte(payload))
+			require.Error(t, err)
+		})
+	}
 }
 
 // TestReportIssuesSourceCode verifies correct diagnostic generation for source
@@ -178,6 +195,121 @@ func TestNpxNotAvailable(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, result)
 	require.Len(t, interceptor.Diagnostics, 0)
+}
+
+func TestRunBoundsReactDetectOutput(t *testing.T) {
+	issues := make([]sourceCodeIssue, 500)
+	for i := range issues {
+		issues[i] = sourceCodeIssue{
+			Pattern:  "usePropTypes",
+			Severity: "critical",
+			Location: location{File: "module.js", Line: i + 1, Column: 1},
+			Problem:  "Uses deprecated propTypes " + strings.Repeat("detail ", 20),
+			Fix:      fix{Description: "Remove propTypes usage."},
+			Link:     "https://react.dev/upgrade",
+		}
+	}
+	largeValidOutput, err := json.Marshal(reactDetectOutput{
+		SourceCodeIssues: map[string][]sourceCodeIssue{"usePropTypes": issues},
+		DependencyIssues: []dependencyIssue{},
+	})
+	require.NoError(t, err)
+	smallValidOutput, err := json.Marshal(reactDetectOutput{
+		SourceCodeIssues: map[string][]sourceCodeIssue{"usePropTypes": issues[:2]},
+		DependencyIssues: []dependencyIssue{},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		stdout      []byte
+		stderr      []byte
+		killed      bool
+		valid       bool
+		totalIssues int
+		truncated   bool
+	}{
+		{name: "small valid output and zero exit", stdout: smallValidOutput, valid: true, totalIssues: 2},
+		{name: "small valid output and killed", stdout: smallValidOutput, killed: true, valid: true, totalIssues: 2},
+		{name: "small invalid output and killed", stdout: []byte("complete invalid output"), killed: true},
+		{name: "large valid output and zero exit", stdout: largeValidOutput, valid: true, totalIssues: len(issues), truncated: true},
+		{name: "large valid output and killed", stdout: largeValidOutput, killed: true, valid: true, totalIssues: len(issues), truncated: true},
+		{
+			name:      "large invalid output and killed",
+			stdout:    []byte(strings.Repeat("invalid output\n", 5000)),
+			stderr:    []byte(strings.Repeat("stderr context\n", 5000)),
+			killed:    true,
+			truncated: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			stdoutFile := filepath.Join(t.TempDir(), "stdout")
+			stderrFile := filepath.Join(t.TempDir(), "stderr")
+			require.NoError(t, os.WriteFile(stdoutFile, tc.stdout, 0o600))
+			require.NoError(t, os.WriteFile(stderrFile, tc.stderr, 0o600))
+
+			termination := "exit 0\n"
+			if tc.killed {
+				termination = "kill -KILL $$\n"
+			}
+			fakeNpx := filepath.Join(binDir, "npx")
+			script := `#!/bin/sh
+/bin/cat "$REACT_DETECT_TEST_STDOUT"
+/bin/cat "$REACT_DETECT_TEST_STDERR" >&2
+` + termination
+			require.NoError(t, os.WriteFile(fakeNpx, []byte(script), 0o755))
+			t.Setenv("REACT_DETECT_TEST_STDOUT", stdoutFile)
+			t.Setenv("REACT_DETECT_TEST_STDERR", stderrFile)
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			var interceptor testpassinterceptor.TestPassInterceptor
+			result, runErr := Analyzer.Run(newPass(&interceptor, t.TempDir()))
+			require.NoError(t, runErr)
+			require.Nil(t, result)
+
+			serialized, marshalErr := json.Marshal(interceptor.Diagnostics)
+			require.NoError(t, marshalErr)
+			require.LessOrEqual(t, len(serialized), maxReportBytes)
+
+			var details strings.Builder
+			issueReports := 0
+			for _, diagnostic := range interceptor.Diagnostics {
+				details.WriteString(diagnostic.Detail)
+				if strings.HasPrefix(diagnostic.Title, "React 19 compatibility: Uses deprecated propTypes") {
+					issueReports++
+				}
+			}
+
+			if tc.valid {
+				require.NotContains(t, details.String(), "signal: killed")
+				if tc.truncated {
+					require.Positive(t, issueReports)
+					require.Less(t, issueReports, tc.totalIssues)
+					require.Contains(t, details.String(), "issues were omitted")
+				} else {
+					require.Equal(t, tc.totalIssues, issueReports)
+					require.NotContains(t, details.String(), "issues were omitted")
+				}
+				return
+			}
+
+			require.Zero(t, issueReports)
+			require.Contains(t, details.String(), "signal: killed")
+			require.Contains(t, details.String(), "invalid output")
+			if len(tc.stderr) > 0 {
+				require.Contains(t, details.String(), "stderr context")
+			}
+			if tc.truncated {
+				require.Contains(t, details.String(), "truncated")
+			} else {
+				require.Contains(t, details.String(), string(tc.stdout))
+				require.NotContains(t, details.String(), "truncated")
+			}
+		})
+	}
 }
 
 // TestReportIssuesCombined verifies that multiple source code issue groups and a


### PR DESCRIPTION
Prevents failed or oversized `react-detect` output from producing oversized validator results.

Valid JSON is still reported after process failures. Serialized reports are capped at 32 KiB with omitted issue counts, and process output capture is bounded.