### PR TITLE
fix: pin govulncheck's Go toolchain in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,12 @@ ARG GOSEC_VERSION
 ARG SEMGREP_VERSION
 
 # govulncheck source mode shells out to the Go command to load packages.
-RUN apk add --no-cache git go ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav 'nodejs=~24' npm
+# Use the base image's own pinned toolchain (/usr/local/go/bin) rather than
+# apk's `go` package, which floats to whatever version is current in Alpine's
+# repo and can drift ahead of the toolchain govulncheck was built with,
+# causing "source-processing packages" / "go list" version-mismatch failures.
+ENV PATH="/usr/local/go/bin:${PATH}"
+RUN apk add --no-cache git ca-certificates curl wget python3 python3-dev py3-pip alpine-sdk clamav 'nodejs=~24' npm
 RUN update-ca-certificates
 RUN freshclam
 


### PR DESCRIPTION
govulncheck was failing with a version mismatch.

The error was caused by the final Docker image installing an unpinned go package via apk alongside the base image's own pinned Go toolchain. When Alpine's go package drifted ahead of the pinned toolchain, `govulncheck` (built against the older toolchain) failed to parse the newer `stdlib` source, causing scans to fail with cryptic parse errors.

This PR removes the redundant, unpinned apk Go install and ensures `/usr/local/go/bin` (the base image's pinned toolchain) is always first on `PATH`, so `govulncheck` and the Go toolchain it shells out to stay in sync.

Closes https://github.com/grafana/grafana-catalog-team/issues/1125