### PR TITLE
fix(release): pin GoReleaser version

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -61,7 +61,8 @@ jobs:
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
-          version: latest
+          # Temporary pin until the missing-tag regression in v2.18.1 is released.
+          version: v2.18.0
           # release-please tags look like `mcp/v0.1.2`, which GoReleaser's
           # validate pipe can't parse as semver. Skip it; the archive name
           # template uses `MCP_VERSION` directly and `release.mode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,8 @@ jobs:
         if: env.skip_goreleaser != 'true'
         with:
           distribution: goreleaser
-          version: latest
+          # Temporary pin until the missing-tag regression in v2.18.1 is released.
+          version: v2.18.0
           # release-please tags look like `plugin-validator/v0.42.0`, which
           # GoReleaser's validate pipe can't parse as semver. Skip it; the
           # archive name template uses `RELEASE_VERSION` directly and


### PR DESCRIPTION
Temporarily pins GoReleaser to v2.18.0 while the v2.18.1 missing-tag regression fix awaits release.

The fix is merged upstream in https://github.com/goreleaser/goreleaser/pull/7124.

This restores releases that use Release Please draft releases.