### PR TITLE
fix(release): build for amd64 and arm64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 


### PR DESCRIPTION
Builds Linux, macOS, and Windows releases for amd64 and arm64, matching MCP’s supported architectures. Drops the 32 bit targets, including the linux/386 build currently failing in osv-scalibr.