### PR TITLE
fix: align Go scanner toolchains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
-ARG GOLANGCI_LINT_VERSION=v2.12.2
+ARG GOLANGCI_LINT_VERSION=v2.13.2
 # SHA256 of golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-amd64.tar.gz from the upstream checksums file.
 # Update whenever GOLANGCI_LINT_VERSION changes.
-ARG GOLANGCI_LINT_SHA256=8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
-ARG GOSEC_VERSION=v2.22.8
-ARG GOVULNCHECK_VERSION=v1.1.4
+ARG GOLANGCI_LINT_SHA256=2277d43b98ec0054280f2ac26b53268bae97682444678a59a657dd565da021d6
+ARG GOSEC_VERSION=v2.29.0
+ARG GOVULNCHECK_VERSION=v1.7.0
 ARG SEMGREP_VERSION=1.84.1
 
-FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
+FROM golang:1.27.1-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS go-base
+
+FROM go-base AS govulncheck
+
+ARG GOVULNCHECK_VERSION
+RUN GOTOOLCHAIN=local CGO_ENABLED=0 go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
+COPY scripts/govulncheck-probe.sh /tmp/govulncheck-probe.sh
+RUN sh /tmp/govulncheck-probe.sh /go/bin/govulncheck
+
+FROM go-base AS builder
 
 ARG GOLANGCI_LINT_VERSION
 ARG GOLANGCI_LINT_SHA256
 ARG GOSEC_VERSION
-ARG GOVULNCHECK_VERSION
 ARG SEMGREP_VERSION
 
 WORKDIR /go/src/github.com/grafana/plugin-validator
@@ -45,10 +53,7 @@ RUN set -eux; \
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | \
     sh -s -- -b /usr/local/bin ${GOSEC_VERSION}
 
-# govulncheck is distributed as a Go module — install with `go install` rather
-# than a binary tarball. Pinned version is fixed via the ARG above.
-RUN go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} && \
-    mv "$(go env GOPATH)/bin/govulncheck" /usr/local/bin/govulncheck
+COPY --from=govulncheck /go/bin/govulncheck /usr/local/bin/govulncheck
 
 # setuptools<81 provides pkg_resources, which semgrep 1.84.1 imports but
 # Python 3.14 (alpine 3.24) no longer bundles. semgrep is pinned to the
@@ -61,7 +66,7 @@ RUN mage -v build:lint
 
 RUN mage -v build:ci
 
-FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83
+FROM go-base
 
 ARG GOSEC_VERSION
 ARG SEMGREP_VERSION
@@ -78,8 +83,7 @@ RUN freshclam
 
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b /usr/local/bin ${GOSEC_VERSION}
 
-# govulncheck is built in the builder stage; copy the static binary in.
-COPY --from=builder /usr/local/bin/govulncheck /usr/local/bin/govulncheck
+COPY --from=govulncheck /go/bin/govulncheck /usr/local/bin/govulncheck
 
 # install semgrep
 RUN python3 -m pip install "setuptools<81" semgrep==${SEMGREP_VERSION} --ignore-installed --break-system-packages --no-cache-dir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/plugin-validator
 
-go 1.26.6
+go 1.27.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/pkg/analysis/passes/gosec/gosec.go
+++ b/pkg/analysis/passes/gosec/gosec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/grafana/plugin-validator/pkg/analysis"
@@ -54,7 +55,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, nil
 	}
 
-	// run gosec
+	sourceCodeDir, err = filepath.Abs(sourceCodeDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// gosec resolves relative file paths against the module root.
 	goSecCommand := exec.Command(
 		goSecBin,
 		"-quiet",
@@ -62,7 +68,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		targetSeverity,
 		"-fmt",
 		"json",
-		"-r",
+		filepath.Join(sourceCodeDir, "..."),
 	)
 	goSecCommand.Dir = sourceCodeDir
 	goSecOutput, err := goSecCommand.Output()

--- a/pkg/analysis/passes/govulncheck/govulncheck.go
+++ b/pkg/analysis/passes/govulncheck/govulncheck.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -23,6 +24,9 @@ import (
 )
 
 var (
+	goRequirementRE = regexp.MustCompile(`requires go >= (?:go)?([0-9]+(?:\.[0-9]+){1,2})`)
+	goVersionRE     = regexp.MustCompile(`go([0-9]+(?:\.[0-9]+){1,2})`)
+
 	govulncheckNotInstalled  = &analysis.Rule{Name: "govulncheck-not-installed", Severity: analysis.Warning}
 	govulncheckScanFailed    = &analysis.Rule{Name: "govulncheck-scan-failed", Severity: analysis.Error}
 	govulncheckIssueFound    = &analysis.Rule{Name: "govulncheck-issue-found", Severity: analysis.Warning}
@@ -201,6 +205,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func runGovulncheckJSON(govulncheckBin, dir, target string, args ...string) ([]byte, bool, string, error) {
 	cmd := exec.Command(govulncheckBin, args...)
 	cmd.Dir = dir
+	cmd.Env = withLocalToolchain(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -216,6 +221,9 @@ func runGovulncheckJSON(govulncheckBin, dir, target string, args ...string) ([]b
 		}
 		if exitErr.ExitCode() != 3 {
 			logme.DebugFln("govulncheck scan failed for %s: %v (stderr: %s)", target, err, stderr.String())
+			if detail := goRequirementDetail(stderr.String(), localGoVersion()); detail != "" {
+				return nil, false, detail, nil
+			}
 			return nil, false, scanFailureDetail(target, stderr.String(), err), nil
 		}
 	}
@@ -300,6 +308,44 @@ func pluralY(n int) string {
 		return "y"
 	}
 	return "ies"
+}
+
+func withLocalToolchain(env []string) []string {
+	for i, value := range env {
+		if strings.HasPrefix(value, "GOTOOLCHAIN=") {
+			env[i] = "GOTOOLCHAIN=local"
+			return env
+		}
+	}
+	return append(env, "GOTOOLCHAIN=local")
+}
+
+func localGoVersion() string {
+	cmd := exec.Command("go", "version")
+	cmd.Env = withLocalToolchain(os.Environ())
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	matches := goVersionRE.FindStringSubmatch(string(output))
+	if len(matches) == 0 {
+		return ""
+	}
+	return "go" + matches[1]
+}
+
+func goRequirementDetail(stderr, supportedVersion string) string {
+	matches := goRequirementRE.FindStringSubmatch(stderr)
+	if len(matches) == 0 {
+		return ""
+	}
+
+	required := "v" + matches[1]
+	supported := strings.TrimPrefix(supportedVersion, "go")
+	if supported == "" || semver.Compare("v"+supported, required) >= 0 {
+		return ""
+	}
+	return fmt.Sprintf("Plugin source requires Go %s or later; this validator supports Go %s.", matches[1], supported)
 }
 
 func scanFailureDetail(target, stderr string, err error) string {

--- a/pkg/analysis/passes/govulncheck/govulncheck_test.go
+++ b/pkg/analysis/passes/govulncheck/govulncheck_test.go
@@ -55,6 +55,72 @@ func TestParseCalledFindings_EmptyStream(t *testing.T) {
 	}
 }
 
+func TestGoRequirementDetail_ReportsHigherRequirement(t *testing.T) {
+	stderr := "go: module example.com/dependency requires go >= 1.28 (running go 1.27.1; GOTOOLCHAIN=local)"
+	got := goRequirementDetail(stderr, "go1.27.1")
+	want := "Plugin source requires Go 1.28 or later; this validator supports Go 1.27.1."
+	if got != want {
+		t.Fatalf("goRequirementDetail() = %q, want %q", got, want)
+	}
+}
+
+func TestGoRequirementDetail_IgnoresSupportedRequirement(t *testing.T) {
+	stderr := "go: module example.com/dependency requires go >= 1.27"
+	if got := goRequirementDetail(stderr, "go1.27.1"); got != "" {
+		t.Fatalf("goRequirementDetail() = %q, want empty", got)
+	}
+}
+
+func TestWithLocalToolchain_ReplacesExistingValue(t *testing.T) {
+	got := withLocalToolchain([]string{"PATH=/bin", "GOTOOLCHAIN=auto"})
+	if strings.Join(got, "\x00") != "PATH=/bin\x00GOTOOLCHAIN=local" {
+		t.Fatalf("withLocalToolchain() = %q", got)
+	}
+}
+
+func TestRunGovulncheckJSON_UsesLocalToolchainForFutureGoDirective(t *testing.T) {
+	const futureGoVersion = "99.0.0"
+
+	binDir := t.TempDir()
+	fakeGovulncheck := filepath.Join(binDir, "govulncheck")
+	envFile := filepath.Join(t.TempDir(), "toolchain")
+	script := "#!/bin/sh\nprintf '%s' \"$GOTOOLCHAIN\" > \"$GOTOOLCHAIN_FILE\"\nexec go list ./...\n"
+	if err := os.WriteFile(fakeGovulncheck, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake govulncheck: %v", err)
+	}
+
+	sourceDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "go.mod"), []byte("module example.com/future\n\ngo " + futureGoVersion + "\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "main.go"), []byte("package future\n"), 0o644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	t.Setenv("GOTOOLCHAIN", "auto")
+	t.Setenv("GOTOOLCHAIN_FILE", envFile)
+	_, ok, detail, err := runGovulncheckJSON(fakeGovulncheck, sourceDir, sourceDir, "-json", "./...")
+	if err != nil {
+		t.Fatalf("runGovulncheckJSON() error = %v", err)
+	}
+	if ok {
+		t.Fatal("runGovulncheckJSON() reported success for an unsupported Go directive")
+	}
+	if !strings.Contains(detail, "Plugin source requires Go "+futureGoVersion+" or later") {
+		t.Fatalf("runGovulncheckJSON() detail = %q", detail)
+	}
+	if !strings.Contains(detail, "this validator supports Go "+strings.TrimPrefix(localGoVersion(), "go")) {
+		t.Fatalf("runGovulncheckJSON() reported the wrong running Go version: %q", detail)
+	}
+	toolchain, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read toolchain marker: %v", err)
+	}
+	if string(toolchain) != "local" {
+		t.Fatalf("scanner received GOTOOLCHAIN=%q, want local", toolchain)
+	}
+}
+
 func TestParseCalledFindings_DedupesSameOSV(t *testing.T) {
 	// Two findings for the same OSV (different call sites) should collapse
 	// into a single entry in the result set.

--- a/scripts/govulncheck-probe.sh
+++ b/scripts/govulncheck-probe.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+scanner=$1
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+db="$work/vulndb-v1"
+mkdir -p "$db/ID" "$db/index"
+printf '%s\n' '{"schema_version":"1.3.1","id":"GO-9999-0001","modified":"2026-01-01T00:00:00Z","published":"2026-01-01T00:00:00Z","summary":"Synthetic probe vulnerability","affected":[{"package":{"name":"stdlib","ecosystem":"Go"},"ranges":[{"type":"SEMVER","events":[{"introduced":"0"},{"fixed":"99.0.0"}]}],"ecosystem_specific":{"imports":[{"path":"net/http","symbols":["Get"]}]}}]}' > "$db/ID/GO-9999-0001.json"
+printf '%s\n' '{"modified":"2026-01-01T00:00:00Z"}' > "$db/index/db.json"
+printf '%s\n' '[{"path":"stdlib","vulns":[{"id":"GO-9999-0001","modified":"2026-01-01T00:00:00Z","fixed":"99.0.0"}]}]' > "$db/index/modules.json"
+printf '%s\n' '[{"id":"GO-9999-0001","modified":"2026-01-01T00:00:00Z"}]' > "$db/index/vulns.json"
+
+fixture=$work/fixture
+mkdir -p "$fixture"
+go_version=$(GOTOOLCHAIN=local go env GOVERSION)
+printf '%s\n' 'module example.com/govulncheck-fixture' '' "go ${go_version#go}" > "$fixture/go.mod"
+printf '%s\n' 'package main' '' 'import "net/http"' '' 'func main() {' '    _, _ = http.Get("https://example.com")' '}' > "$fixture/main.go"
+
+(cd "$fixture" && GOTOOLCHAIN=local "$scanner" -db "file://$db" -scan symbol -json ./... > "$work/scan.json")
+grep -Eq '"scanner_name"[[:space:]]*:[[:space:]]*"govulncheck"' "$work/scan.json"
+grep -Eq '"scan_level"[[:space:]]*:[[:space:]]*"symbol"' "$work/scan.json"
+grep -Eq '"osv"[[:space:]]*:[[:space:]]*"GO-9999-0001"' "$work/scan.json"
+grep -Eq '"function"[[:space:]]*:[[:space:]]*"Get"' "$work/scan.json"
+grep -Eq '"function"[[:space:]]*:[[:space:]]*"main"' "$work/scan.json"
+printf '%s\n' 'govulncheck completed source analysis and reported the synthetic call trace'


### PR DESCRIPTION
Builds govulncheck with the runtime’s Go toolchain and updates the scanners for Go 1.27 compatibility. Adds an offline source scan check during image builds and explicit diagnostics for unsupported Go requirements. Fixes gosec source path resolution.